### PR TITLE
Add S3 TransferManager client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :java-source-paths ["src/main/java"]
   :target-path "target"
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [com.amazonaws/aws-java-sdk "1.5.0"]
+                 [com.amazonaws/aws-java-sdk "1.5.4"]
                  [org.clojure/algo.generic "0.1.0"]
                  [joda-time "2.1"]
                  [robert/hooke "1.3.0"]])

--- a/src/amazonica/aws/s3transfer.clj
+++ b/src/amazonica/aws/s3transfer.clj
@@ -1,0 +1,46 @@
+(ns amazonica.aws.s3transfer
+  (:use [amazonica.core :only (IMarshall marshall register-coercions coerce-value)]
+        [clojure.algo.generic.functor :only (fmap)])
+  (:import [com.amazonaws.services.s3.transfer
+            TransferManager
+            Transfer
+            TransferProgress
+            Upload])
+  (:import [com.amazonaws.services.s3.model
+            ProgressListener]))
+
+(extend-protocol IMarshall
+  TransferProgress
+  (marshall [obj]
+    {:total-bytes-to-transfer (.getTotalBytesToTransfer obj)
+    :bytes-transferred (.getBytesTransferred obj)
+    :percent-transferred (.getPercentTransferred obj)})
+
+  Upload
+  (marshall [obj]
+    {:upload-result #(marshall (.waitForUploadResult obj))
+     :add-progress-listener #(.addProgressListener obj %)
+     :get-description #(.getDescription obj)
+     :get-progress #(marshall (.getProgress obj))
+     :get-state #(str (.getState obj))
+     :is-done #(.isDone obj)
+     :remove-progress-listener #(.removeProgressListener obj %)
+     :wait-for-completion #(.waitForCompletion obj)
+     :wait-for-exception #(marshall (.waitForException obj))}))
+
+(register-coercions
+  ProgressListener
+  (fn [col]
+    (proxy
+      [ProgressListener] []
+      (progressChanged [event]
+        ((:progress-changed col) event)))))
+
+(amazonica.core/set-client TransferManager *ns*)
+
+(defn new-progress-listener
+  "This helper function returns an object implementing the ProgressListener interface.
+  The argument progress-changed is a function taking a single ProgressEvent argument."
+  [progress-changed]
+  (let [col {:progress-changed progress-changed}]
+    (coerce-value col ProgressListener)))

--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -20,6 +20,7 @@
            java.io.StringWriter
            java.lang.reflect.InvocationTargetException
            java.lang.reflect.ParameterizedType
+           java.lang.reflect.Modifier
            java.math.BigDecimal
            java.math.BigInteger
            java.text.ParsePosition
@@ -601,7 +602,8 @@
   "Finds the appropriate method to invoke in cases where
   the Amazon*Client has overloaded methods by arity or type."
   [methods & arg]
-  (let [args (:args (args-from arg))]
+  (let [args (:args (args-from arg))
+        methods (filter #(not (Modifier/isPrivate (.getModifiers %))) methods)]
     (some
       (fn [method]
         (let [types (.getParameterTypes method)


### PR DESCRIPTION
- Update amazon aws java sdk version to latest (1.5.4)
  so that TransferManager methods work properly
- Add helper function for creating ProgressListeners
- Change best-method to only consider non-private methods
