### PR TITLE
Add S3 input stream upload example to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -758,6 +758,14 @@ Amazonica uses reflection extensively, to generate the public Vars, to set the b
             :key "foo")))))            
 
 
+;; put object from stream
+(def some-bytes (.getBytes "Amazonica" "UTF-8"))
+(def input-stream (java.io.ByteArrayInputStream. some-bytes))
+(put-object :bucket-name bucket1
+            :key "stream"
+            :input-stream input-stream
+            :metadata {:content-length (count some-bytes)})
+
 
 (let [upl (upload bucket
                   file


### PR DESCRIPTION
I thought it might be handy to add an example of using an `InputStream` to create an S3 object to the readme. It took me a few clicks around the Amazon documentation to find the right parameter name, and this might save someone some time.
