### PR TITLE
Add client configuration parameters to the credentials map

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,14 @@ All subsequent API calls will use the specified credential. If you need to execu
 ; returns images belonging to account-1
 ```  
 
+### Client configuration
+
+You can supply a `:client-config` entry in the credentials map to configure the [ClientConfiguration](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html) that the Amazon client uses. This is useful if you need to use a proxy.
+
+```clj
+(describe-images {:client-config {:proxy-host "proxy.address.com" :proxy-port 8080}})
+```
+
 
 ### Exception Handling  
 All functions throw `com.amazonaws.AmazonServiceExceptions`. If you wish to catch exceptions you can convert the AWS object to a Clojure map like so:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amazonica "0.1.21"
+(defproject amazonica "0.1.22-SNAPSHOT"
   :description "A comprehensive Clojure client for the entire Amazon AWS api."
   :url "https://github.com/mcohen01/amazonica"
   :license {:name "Eclipse Public License"

--- a/test/amazonica/test/s3.clj
+++ b/test/amazonica/test/s3.clj
@@ -79,6 +79,45 @@
                        :key "jenny")))))
   
   
+
+  ;; upload file with credentials and client options
+  (put-object
+   (assoc cred :client-config {:max-connections 1
+                                :user-agent "Amazonica"})
+   :bucket-name bucket1
+   :key "creds-and-options"
+   :file upload-file)
+
+  (is (= "hello world"
+         (slurp (:input-stream
+                 (get-object :bucket-name bucket1
+                             :key "creds-and-options")))))
+
+  ;; upload file with just creds
+  (put-object
+   cred
+   :bucket-name bucket1
+   :key "creds"
+   :file upload-file)
+
+  (is (= "hello world"
+         (slurp (:input-stream
+                 (get-object :bucket-name bucket1
+                             :key "creds")))))
+
+  ;; upload file without credentials but with client options
+  (put-object
+   {:client-config {:max-connections 1
+                    :user-agent "Amazonica"}}
+   :bucket-name bucket1
+   :key "options"
+   :file upload-file)
+
+  (is (= "hello world"
+         (slurp (:input-stream
+                 (get-object :bucket-name bucket1
+                             :key "options")))))
+
   (.createNewFile upload-file)
   (spit upload-file (Date.))  
 
@@ -107,6 +146,9 @@
   
   
   (delete-object bucket1 "jenny")
+  (delete-object bucket1 "creds-and-options")
+  (delete-object bucket1 "options")
+  (delete-object bucket1 "creds")
   (delete-bucket bucket1)
   
   (def bucket1 (.. (UUID/randomUUID) toString))


### PR DESCRIPTION
This change allows you to configure the Amazon clients with the [ConfigurationBean](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/ClientConfiguration.html). I'm going to use it to configure a proxy but it's useful if you need finer control over the configuration of the clients.

I've added some words to the readme to describe the additional configuration and tests to check that the client works as expected. It's difficult to write tests that require a proxy, but I've installed the snapshot version and verified that it behaves as expected.

I've not run all of the tests because I need to set up my environment to look like yours. I've run the tests and they run in the same was as the master branch.

I've also just noticed that my editor has removed whitespace at the end of some of the lines. If that's a problem I'll submit another pull request with exactly the modifications required for this change.
