### PR TITLE
Allow setting the actual endpoint, not the region on the AWS client.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amazonica "0.1.27"
+(defproject amazonica "0.1.28-DEVELOPMENT"
   :description "A comprehensive Clojure client for the entire Amazon AWS api."
   :url "https://github.com/mcohen01/amazonica"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
In order to use the new, local DynamoDB client from Amazon, you need to be able to call the .setEndpoint method on the AWSClient instance.  I've slightly updated amazonica.core to draw a distinction between the region string and the actual endpoint.  Now you can have a credentials map like 
{:access-key "?" :secret-key "?" :endpoint "http://localhost:8000"}.
