### PR TITLE
allow cred with endpoint only, for IAM instance profile running client out of default region.

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -666,6 +666,7 @@
       (or (and (or (map? args)
                    (map? (first args)))
                (or (contains? (first args) :access-key)
+                   (contains? (first args) :endpoint)
                    (contains? (first args) :client-config)))
           (instance? AWSCredentialsProvider (first args))
           (instance? AWSCredentials (first args)))


### PR DESCRIPTION
currently, I'm doing workaround like below, for IAM instance profile running client in non us-east-1 region.
(describe-instances {:endpoint region :client-config {:protocol "https"}})
But I'd like to be able to specify it like below.
(describe-instances {:endpoint region})
