### PR TITLE
Fix Typo in coerce-value

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -307,7 +307,7 @@
         (throw (IllegalArgumentException.
                  (format "No coercion is available to turn %s into an object of type %s"
                          value type)))))
-    val))
+    value))
 
 (defn- default-value
   [class-name]


### PR DESCRIPTION
Use the passed in value, not the "val" function.
