### PR TITLE
allow setting endpoint without trampling credentials

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -690,12 +690,12 @@
       (if (= clazz TransferManager)
           (TransferManager. (candidate-client AmazonS3Client args))
           (encryption-client (:encryption (apply hash-map (:args args)))
-                             (or (:credential args) @credential)
+                             (merge @credential (:credential args))
                                  (:client-config args)))
       (if (= clazz TransferManager)
           (TransferManager. (candidate-client AmazonS3Client args))
           (amazon-client clazz
-                         (or (:credential args) @credential)
+                         (merge @credential (:credential args))
                          (:client-config args)))))
 
 (defn- fn-call


### PR DESCRIPTION
I'd like to specify the endpoint without changing the credentials, so that I can do something like

```
(defcredential ":access-key" ":secret-key" "us-west-1")
(ec2/run-instances {:endpoint "us-east-1"} run-instance-args)
```

This might not be the right approach, but maybe it will get some discussion going.
