### PR TITLE
Allow client to configure the KinesisClientLibConfiguration

### DIFF
--- a/src/amazonica/aws/kinesis.clj
+++ b/src/amazonica/aws/kinesis.clj
@@ -216,4 +216,3 @@
         uuid (.getWorkerIdentifier worker)]
     (future (.run worker))
     uuid))
-


### PR DESCRIPTION
The PR exposes the configuration of the KinesisClientLibConfiguration to the client via arguments to the worker functions. It also decouples the instantiation of the Worker from the invocation of the Worker's run method. This can be helpful when local development demands frequent starting and stopping of a Worker.
