### PR TITLE
Allow endpoint without credentials to be supplied as first argument to parse-args

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -167,9 +167,10 @@
   "Legacy support means credentials may or may not be passed
    as the first argument."
   [cred args]
-  (if (instance? DefaultAWSCredentialsProviderChain (get-credentials cred))
-      {:args (conj args cred)}
-      {:args args :cred cred}))
+  (if (and (instance? DefaultAWSCredentialsProviderChain (get-credentials cred))
+           (nil? (:endpoint cred)))
+    {:args (conj args cred)}
+    {:args args :cred cred}))
 
 (declare create-bean)
 


### PR DESCRIPTION
It is my understanding that it should be possible to use credentials and an endpoint as the first argument to aws api functions. It appears that for functions modified by alter-var-root that use the parse-args function in core do not allow you to pass only an endpoint, because they expect credentials. This pull request should make it possible to pass an endpoint but not credentials for cases where credentials will be obtained by other methods.
