### PR TITLE
fallback to default region (& endpoint) from environment.

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -200,7 +200,8 @@
   (let [aws-creds  (get-credentials credentials)
         aws-config (get-client-configuration configuration)
         client     (create-client clazz aws-creds aws-config)]
-    (when-let [endpoint (:endpoint credentials)]
+    (when-let [endpoint (or (:endpoint credentials)
+                            (System/getenv "AWS_DEFAULT_REGION"))]
       (if (contains? (fmap #(-> % str/upper-case (str/replace "_" ""))
                            (apply hash-set (seq (Regions/values))))
                      (-> (str/upper-case endpoint)


### PR DESCRIPTION
This makes amazonica fallback to the region endpoint specified by the `AWS_DEFAULT_REGION` env var if it's specified and not supplied in the credentials map. This allows 0 arg invocation of various fns when you don't want `us-east-1` as your default region.
