### PR TITLE
Support :cred key in credential map

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -167,6 +167,9 @@
          (contains? credentials :profile))
     (ProfileCredentialsProvider.
         (:profile credentials))
+    (and (associative? credentials)
+         (instance? AWSCredentialsProvider (:cred credentials)))
+    (:cred credentials)
     :else
     (DefaultAWSCredentialsProviderChain.)))
 


### PR DESCRIPTION
The documentation describes the :cred key in the credential map as containing an AWSCredentialProvider to pass to the client, but the key is not used. It looks like the problem was not parsing the :cred key out (except maybe for some special clients). So this commit will parse the :cred key if it's an instance of an AWSCredentialProvider.
