### PR TITLE
Added examples of using non-scalar data with dynamodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,11 @@ Amazonica uses reflection extensively, to generate the public Vars, to set the b
             :date 123456
             :text "barbaz"
             :column1 "first name"
-            :column2 "last name"})
+            :column2 "last name"
+            :numberSet #{1 2 3}
+            :stringSet #{"foo" "bar"}
+            :mixedList [1 "foo"]
+            :mixedMap {:name "baz" :secret 42}})
 
 (get-item cred
           :table-name "TestTable"


### PR DESCRIPTION
issue #76 

I realized that there is a slight breaking change with how AttributeValue is coerced: Previously a vector was coerced to a number-set or string-set, but now clojure vectors are coerced to lists. I think this is reasonable as number-sets and string-sets are marshalled as clojure sets. That is, to represent a number-set or string-set you should use a clojure set. 

Hopefully this documentation explains how to use the non-scalar types.
