### PR TITLE
Add exclusions for joda-time to aws-java-sdk, amazon-kinesis-client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,9 +9,9 @@
   :deploy-repositories [["releases" :clojars]]
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/algo.generic "0.1.2"]
-                 [com.amazonaws/aws-java-sdk "1.9.7"]
+                 [com.amazonaws/aws-java-sdk "1.9.7" :exclusions [joda-time]]
                  [org.apache.httpcomponents/httpclient "4.3.3"]
-                 [com.amazonaws/amazon-kinesis-client "1.1.0"]
+                 [com.amazonaws/amazon-kinesis-client "1.1.0" :exclusions [joda-time]]
                  [joda-time "2.2"]
                  [robert/hooke "1.3.0"]
                  [com.taoensso/nippy "2.5.0"]])


### PR DESCRIPTION
Amazonica itself depends on `joda-time` 2.2, but `aws-java-sdk` and `amazon-kinesis-client` pull it in transitively with a version range, which Leiningen 2.5 rightly detests:

```
: jmglov@alhana; lein install
WARNING!!! version ranges found for:
[com.amazonaws/amazon-kinesis-client "1.1.0"] -> [com.amazonaws/aws-java-sdk "1.7.13"] -> [joda-time "[2.2,)"]
Consider using [com.amazonaws/amazon-kinesis-client "1.1.0" :exclusions [joda-time]].
[com.amazonaws/aws-java-sdk "1.9.7"] -> [com.amazonaws/aws-java-sdk-elasticloadbalancing "1.9.7"] -> [com.amazonaws/aws-java-sdk-core "1.9.7"] -> [joda-time "[2.2,)"]
Consider using [com.amazonaws/aws-java-sdk "1.9.7" :exclusions [joda-time]].

[...]
```

I have considered using the exclusion. ;)
