### PR TITLE
Set region/endpoint on s3 client when using s3 transfermanager

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -736,11 +736,11 @@
                    (:encryption (apply hash-map (:args args))))
         client  (if (and crypto (or (= clazz AmazonS3Client)
                                     (= clazz TransferManager)))
-                    (encryption-client crypto credential client-config)
-                    (amazon-client clazz credential client-config))]
+                    (delay (encryption-client crypto credential client-config))
+                    (delay (amazon-client clazz credential client-config)))]
         (if (= clazz TransferManager)
             (transfer-manager credential client-config crypto)
-            client)))
+            @client)))
         
 
 (defn- fn-call

--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -205,6 +205,18 @@
       (AmazonS3EncryptionClient. creds materials config crypto)
       (AmazonS3EncryptionClient. creds materials crypto))))
 
+(defn- ^:private set-region
+  [clazz client endpoint]
+    (if (isa? TransferManager clazz)
+      (.setRegion (.getAmazonS3Client client) endpoint)
+      (.setRegion client endpoint)))
+
+(defn- ^:private set-endpoint
+  [clazz client endpoint]
+    (if (isa? TransferManager clazz)
+      (.setEndpoint (.getAmazonS3Client client) endpoint)
+      (.setEndpoint client endpoint)))
+
 (defn- amazon-client*
   [clazz credentials configuration]
   (let [aws-creds  (get-credentials credentials)
@@ -221,10 +233,10 @@
                      (str/replace "-" "_"))
                  Regions/valueOf
                  Region/getRegion
-                 (.setRegion client))
+                 (set-region clazz client))
             (catch NoSuchMethodException e
               (println e)))
-          (.setEndpoint client endpoint)))
+          (set-endpoint clazz client endpoint)))
     client))
 
 (def ^:private encryption-client

--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -205,18 +205,6 @@
       (AmazonS3EncryptionClient. creds materials config crypto)
       (AmazonS3EncryptionClient. creds materials crypto))))
 
-(defn- ^:private set-region
-  [clazz client endpoint]
-    (if (isa? TransferManager clazz)
-      (.setRegion (.getAmazonS3Client client) endpoint)
-      (.setRegion client endpoint)))
-
-(defn- ^:private set-endpoint
-  [clazz client endpoint]
-    (if (isa? TransferManager clazz)
-      (.setEndpoint (.getAmazonS3Client client) endpoint)
-      (.setEndpoint client endpoint)))
-
 (defn- amazon-client*
   [clazz credentials configuration]
   (let [aws-creds  (get-credentials credentials)
@@ -233,10 +221,10 @@
                      (str/replace "-" "_"))
                  Regions/valueOf
                  Region/getRegion
-                 (set-region clazz client))
+                 (.setRegion client))
             (catch NoSuchMethodException e
               (println e)))
-          (set-endpoint clazz client endpoint)))
+          (.setEndpoint client endpoint)))
     client))
 
 (def ^:private encryption-client


### PR DESCRIPTION
Breaks when using with defcredential.

```
user=> (use 'amazonica.core)
nil
user=> (use 'amazonica.aws.s3transfer)
nil
user=> (defcredential "s" "x" "x")
{:endpoint "x", :access-key "s", :secret-key "x"}
user=> (download "x" "y" "z")

IllegalArgumentException No matching method found: setEndpoint for class com.amazonaws.services.s3.transfer.TransferManager  clojure.lang.Reflector.invokeMatchingMethod (Reflector.java:53)
```