### PR TITLE
get set-bucket-cross-origin-configuration to work

### DIFF
--- a/src/amazonica/aws/s3.clj
+++ b/src/amazonica/aws/s3.clj
@@ -7,6 +7,8 @@
            [com.amazonaws.services.s3.model
               AccessControlList
               CanonicalGrantee
+              CORSRule
+              CORSRule$AllowedMethods
               DeleteObjectsRequest$KeyVersion
               EmailAddressGrantee
               Grant
@@ -19,6 +21,9 @@
 (def email-pattern #"^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$;")
 
 (extend-protocol IMarshall
+  CORSRule$AllowedMethods
+  (marshall [obj]
+    (.toString obj))
   ObjectMetadata
   (marshall [obj]
     {:cache-control           (.getCacheControl obj)
@@ -122,6 +127,25 @@
   (fn [value]
     (if (coll? value)
         (DeleteObjectsRequest$KeyVersion. (first value) (second value))
-        (DeleteObjectsRequest$KeyVersion. value))))
+        (DeleteObjectsRequest$KeyVersion. value)))
+  CORSRule
+  (fn [col]
+    (let [cors (CORSRule.)]
+      (when-let [id (:id col)]
+        (.setId cors id))
+      (when-let [max-age-seconds (:max-age-seconds col)]
+        (.setMaxAgeSeconds cors max-age-seconds))
+      (when-let [allowed-headers (:allowed-headers col)]
+        (.setAllowedHeaders cors (into-array String allowed-headers)))
+      (when-let [allowed-origins (:allowed-origins col)]
+        (.setAllowedOrigins cors (into-array String allowed-origins)))
+      (when-let [exposed-headers (:exposed-headers col)]
+        (.setExposedHeaders cors (into-array String exposed-headers)))
+      (when-let [allowed-methods (:allowed-methods col)]
+        (.setAllowedMethods cors
+                            (into-array CORSRule$AllowedMethods
+                    (fmap #(coerce-value % CORSRule$AllowedMethods)
+                          allowed-methods))))
+      cors)))
 
 (amazonica.core/set-client AmazonS3Client *ns*)

--- a/test/amazonica/test/s3.clj
+++ b/test/amazonica/test/s3.clj
@@ -308,6 +308,10 @@
     (set-bucket-lifecycle-configuration cred bucket1 config)
     (is (= config (get-bucket-lifecycle-configuration cred bucket1))))
 
+  (set-bucket-cross-origin-configuration cred bucket1 {:rules [{:allowed-methods ["GET" "POST"]
+                                                                :allowed-origins ["*"]
+                                                                :max-age-seconds 9000
+                                                                :allowed-headers ["Authorization"]}]})
   (delete-bucket-cross-origin-configuration cred bucket1)
   (delete-bucket-lifecycle-configuration cred bucket1)
   (delete-bucket-policy cred bucket1)


### PR DESCRIPTION
Noticed that marshalling and coercing cors config didn't behave as I expected and rolled the following custom functions.

To illustrate the problem (with `creds` and `bucket` being vars to my S3 credentials and a test bucket):

Without the change:

```clojure
user=> (amazonica.aws.s3/get-bucket-cross-origin-configuration cred bucket)
{:rules [{:allowed-origins ["*"], :allowed-methods [{} {}], :max-age-seconds 9000, :allowed-headers ["Authorization"]}]}
user=> ;; Notice the {} {} ^^ above
user=> (def my-rules-dict
  #_=>         {:rules [{:allowed-methods ["GET" "POST"]
  #_=>                   :allowed-origins ["*"]
  #_=>                   :max-age-seconds 9000
  #_=>                   :allowed-headers ["Authorization"]}]})
#'user/my-rules-dict
user=> (amazonica.aws.s3/set-bucket-cross-origin-configuration cred bucket my-rules-dict)

IllegalArgumentException No coercion is available to turn Authorization into an object of type class [Ljava.lang.String;  amazonica.core/coerce-value (core.clj:318)
```

After the change:

```clojure
user=>  (amazonica.aws.s3/set-bucket-cross-origin-configuration cred bucket my-rules-dict)
nil
user=> (amazonica.aws.s3/get-bucket-cross-origin-configuration cred bucket)
{:rules [{:allowed-origins ["*"], :allowed-methods ["GET" "POST"], :max-age-seconds 9000, :allowed-headers ["Authorization"]}]}

user=> (amazonica.aws.s3/set-bucket-cross-origin-configuration cred bucket
  #_=>  {:rules [{:allowed-origins ["*"], :allowed-headers ["Authorization"], :allowed-methods ["GET"], :max-age-seconds 1000}]})
nil
user=> (amazonica.aws.s3/get-bucket-cross-origin-configuration cred bucket)
{:rules [{:allowed-origins ["*"], :allowed-methods ["GET"], :max-age-seconds 1000, :allowed-headers ["Authorization"]}]}
```