### PR TITLE
Extend defcredential and with-credentials

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -116,17 +116,21 @@
 (defn defcredential
   "Specify the AWS access key, secret key and optional
   endpoint to use on subsequent requests."
-  [access-key secret-key & [endpoint]]
-  (reset!
-    credential
-    (keys->cred access-key secret-key endpoint)))
+  ([cred]
+   (reset! credential cred))
+  ([access-key secret-key & [endpoint]]
+   (defcredential (keys->cred access-key secret-key endpoint))))
 
 (defmacro with-credential
   "Per invocation binding of credentials for ad-hoc
   service calls using alternate user/password combos
   (and endpoints)."
   [cred & body]
-  `(binding [*credentials* (apply keys->cred ~cred)]
+  `(binding [*credentials*
+             (let [cred# ~cred]
+               (if (sequential? cred#)
+                 (apply keys->cred cred#)
+                 cred#))]
     (do ~@body)))
 
 (declare new-instance)


### PR DESCRIPTION
In continuation of https://github.com/mcohen01/amazonica/issues/131

This modifies with-credentials and defcredential to allow providing credentials with require session token instead of passing credentials into every call.  Additionally, this also allows you to do (with-credential {:profile "prod" :endpoint "us-west-2"} ... ) which is kinda cool.

The version number still needs to be bumped, but with ecs still in flight not sure it will  probably be 0.3.23 and result in merge conflicts. Alternatively, you could merge before ecs and include it in the 0.3.22 release if nothing else needs changed. 