### PR TITLE
Coerce owner when creating AccessControlList

### DIFF
--- a/src/amazonica/aws/s3.clj
+++ b/src/amazonica/aws/s3.clj
@@ -108,7 +108,9 @@
           (coerce-value (first grant) Grantee)
           (coerce-value (second grant) Permission)))
       ;; s3 complains about ACLs without owners (even though docs say internal)
-      (.setOwner acl (or (:owner col) (owner)))
+      (if-let [o (:owner col)]
+        (.setOwner acl (coerce-value o Owner))
+        (.setOwner acl (owner)))
       acl))
   Grant
   (fn [value]


### PR DESCRIPTION
At present the Owner object within an AccessControlList would need to have been constructed manually to avoid:

```
ClassCastException clojure.lang.PersistentArrayMap cannot be cast to com.amazonaws.services.s3.model.Owner  amazonica.aws.s3/eval7228/fn--7251 (s3.clj:111)
```

... when using the following:

```clojure
(s3/set-bucket-acl "bucket-name" {:owner {:id "some-id" :displayName "The Name"} :grant-all [["AuthenticatedUsers" "FULL_CONTROL"]]})
```

This pull request uses `coerce-value` to create the Owner object from the map.