### PR TITLE
Using aws-java-sdk 1.10.5.1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   :deploy-repositories [["releases" :clojars]]
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/algo.generic "0.1.2"]
-                 [com.amazonaws/aws-java-sdk "1.9.33" :exclusions [joda-time]]
+                 [com.amazonaws/aws-java-sdk "1.10.5.1" :exclusions [joda-time]]
                  [org.apache.httpcomponents/httpclient "4.3.3"]
                  [com.amazonaws/amazon-kinesis-client "1.1.0" :exclusions [joda-time]]
                  [joda-time "2.2"]


### PR DESCRIPTION
Please consider this upgrade to 1.10.5.1 in order to avoid excessive logging, see
[426](https://github.com/aws/aws-sdk-java/issues/426).
