### PR TITLE
Add AWS Support service

### DIFF
--- a/src/amazonica/aws/support.clj
+++ b/src/amazonica/aws/support.clj
@@ -1,0 +1,5 @@
+(ns amazonica.aws.support
+  (:require [amazonica.core :as amz])
+  (:import com.amazonaws.services.support.AWSSupportClient))
+
+(amz/set-client AWSSupportClient *ns*)


### PR DESCRIPTION
This pull request adds support for the AWS Support service (which allows the querying of Trusted Advisor checks via the APIs).