### PR TITLE
Add a coercion for SNS MessageAttributeValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1309,7 +1309,8 @@ To put metric data.   [UnitTypes](http://docs.aws.amazon.com/AmazonCloudWatch/la
 
 (publish :topic-arn "arn:aws:sns:us-east-1:676820690883:my-topic"
          :subject "test"
-         :message (str "Todays is " (java.util.Date.)))
+         :message (str "Todays is " (java.util.Date.))
+         :message-attributes {"attr" "value"})
 
 (unsubscribe :subscription-arn "arn:aws:sns:us-east-1:676820690883:my-topic:33fb2721-b639-419f-9cc3-b4adec0f4eda")
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amazonica "0.3.38"
+(defproject amazonica "0.3.39"
   :description "A comprehensive Clojure client for the entire Amazon AWS api."
   :url "https://github.com/mcohen01/amazonica"
   :license {:name "Eclipse Public License"

--- a/src/amazonica/aws/sns.clj
+++ b/src/amazonica/aws/sns.clj
@@ -1,5 +1,16 @@
 (ns amazonica.aws.sns
   (:require [amazonica.core :as amz])
-  (:import com.amazonaws.services.sns.AmazonSNSClient))
+  (:import com.amazonaws.services.sns.AmazonSNSClient
+           [com.amazonaws.services.sns.model MessageAttributeValue]))
+
+(amz/register-coercions
+  MessageAttributeValue
+  (fn [value]
+    (cond
+      (string? value) (doto (MessageAttributeValue.) (.withDataType "String") (.withStringValue value))
+      (number? value) (doto (MessageAttributeValue.) (.withDataType "Number") (.withStringValue (str value)))
+      :else (throw (ex-info
+                     (format "Values of type %s are not supported for SNS Message Attributes" (class value))
+                     {:value value})))))
 
 (amz/set-client AmazonSNSClient *ns*)


### PR DESCRIPTION
Message attributes are useful for sending Windows Phone WNS push notifications via SNS:

* http://docs.aws.amazon.com/sns/latest/dg/SNSMessageAttributes.html
* http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sns/model/MessageAttributeValue.html

This PR adds support for String and Number types.  Binary types are also supported by the AWS SDK but not yet supported in Amazonica - an exception will be thrown instead.