### PR TITLE
Fixes #185 - Support for CloudWatch Logs

### DIFF
--- a/src/amazonica/aws/cloudwatchlogs.clj
+++ b/src/amazonica/aws/cloudwatchlogs.clj
@@ -1,0 +1,5 @@
+(ns amazonica.aws.cloudwatchlogs
+  (:require [amazonica.core :as amz])
+  (:import com.amazonaws.services.logs.AWSLogsClient))
+
+(amz/set-client AWSLogsClient *ns*)


### PR DESCRIPTION
Adds CloudWatch Logs API support.

Some things up for debate:

* Amazon calls this `AWSLogs`, but then goes on to say that it's for CloudWatch Logs.  I find that naming confusing, so I called it `cloudwatchlogs`.  I think there's a strong case for keeping consistent naming with Amazon, but also, them calling it that made it take much longer to find the correct portion of the SDK when googling
* I'm very new to Clojure, and I didn't really grok the testing strategy for the library.  If you like this PR in principle, I would like to add tests.  Do you have any guidance there?