### PR TITLE
Added support for the Amazon Container Registry (ecr)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amazonica "0.3.43"
+(defproject amazonica "0.3.44"
   :description "A comprehensive Clojure client for the entire Amazon AWS api."
   :url "https://github.com/mcohen01/amazonica"
   :license {:name "Eclipse Public License"
@@ -9,7 +9,7 @@
   :deploy-repositories [["releases" :clojars]]
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/algo.generic "0.1.2"]
-                 [com.amazonaws/aws-java-sdk "1.10.28" :exclusions [joda-time]]
+                 [com.amazonaws/aws-java-sdk "1.10.44" :exclusions [joda-time]]
                  [com.amazonaws/amazon-kinesis-client "1.6.1" :exclusions [joda-time]]
                  [joda-time "2.8.1"]
                  [robert/hooke "1.3.0"]

--- a/src/amazonica/aws/ecr.clj
+++ b/src/amazonica/aws/ecr.clj
@@ -1,0 +1,5 @@
+(ns amazonica.aws.ecr
+  (:require [amazonica.core :as amz])
+  (:import [com.amazonaws.services.ecr AmazonECRClient]))
+
+(amz/set-client AmazonECRClient *ns*)


### PR DESCRIPTION
This pull request adds support for the Amazon Container Registry (ecr), its Amazons in-house docker registry service. This service is currently only available in the us-east region.

Thanks for the library, adding support for a new aws api was trivial, after never having used the library  I forked, added 1 file & 5 minutes later was experimenting with the new api in a repl. It was a very pleasant surprise.