### PR TITLE
Add support for ACM.

### DIFF
--- a/src/amazonica/aws/certificatemanager.clj
+++ b/src/amazonica/aws/certificatemanager.clj
@@ -1,0 +1,5 @@
+(ns amazonica.aws.certificatemanager
+  (:require [amazonica.core :as amz])
+  (:import com.amazonaws.services.certificatemanager.AWSCertificateManagerClient))
+
+(amz/set-client AWSCertificateManagerClient *ns*)


### PR DESCRIPTION
This adds support for the new AWS Certificate Manager service (currently only us-east-1).

One thing I noticed is that this new API breaks the way Amazonica handles API calls w/o any required parameters. For example, [ListCertificates](http://docs.aws.amazon.com/acm/latest/APIReference/API_ListCertificates.html) doesn't require any parameters, but the [listCertificates](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-acm/src/main/java/com/amazonaws/services/certificatemanager/AWSCertificateManager.java#L193) method requires a parameter. I'm not sure what to do about that.

A temporary workaround is to always pass a parameter, like `:max-items 100`, but it's odd.