### PR TITLE
fix for getting creds from env

### DIFF
--- a/src/amazonica/aws/kinesisfirehose.clj
+++ b/src/amazonica/aws/kinesisfirehose.clj
@@ -70,10 +70,14 @@
      (let [{:keys [cred] [delivery-stream-name data :as args] :args} (amz/parse-args (first args) (rest args))
            b (->bytes data)]
        (cond (and (string? delivery-stream-name) b)
-             (f cred :delivery-stream-name delivery-stream-name :record {:data b})
+             (if cred
+               (f cred :delivery-stream-name delivery-stream-name :record {:data b})
+               (f :delivery-stream-name delivery-stream-name :record {:data b}))
              
              (map? delivery-stream-name)
-             (f cred (maybe-update-in delivery-stream-name [:record :data] ->bytes))
+             (if cred
+               (f cred (maybe-update-in delivery-stream-name [:record :data] ->bytes))
+               (f (maybe-update-in delivery-stream-name [:record :data] ->bytes)))
              
              (and (keyword? delivery-stream-name) (even? (count args)))
              (put-record-impl cred (apply array-map args))


### PR DESCRIPTION
Hi,

If you call put records without creds, you get an exception saying:

IllegalArgumentException Could not determine best method to invoke for put-record using arguments (nil :delivery-stream-name "test-stream" :record {:data #object[java.nio.HeapByteBuffer 0x57d8447f "java.nio.HeapByteBuffer[pos=0 lim=8 cap=8]"]})

This patch should fix that. Would appreciate a quick release.

Many thanks,

Ed
