### PR TITLE
Add support for AWS IoT

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ and the following dependency:
 * [ElasticTranscoder] (#elastictranscoder)
 * [Glacier] (#glacier)
 * [IdentityManagement] (#identitymanagement)
+* [IoT] (#iot)
 * [Kinesis] (#kinesis)
 * [KinesisFirehose] (#kinesisfirehose)
 * [KMS] (#kms)
@@ -924,6 +925,25 @@ To put metric data.   [UnitTypes](http://docs.aws.amazon.com/AmazonCloudWatch/la
 
 ```
 
+### IoT
+
+```clj
+(ns com.example
+  (:require [amazonica.aws.iot :refer :all]))
+
+(list-things {})
+;; => {:things [{:thing-name "YourThing"}]}
+
+(create-thing :thing-name "MyThing")
+;; => {:thing-name "MyThing" :thing-arn "arn:aws:iot:...thing/MyThing"}
+```
+
+```clj
+(ns com.example
+  (:require [amazonica.aws.iotdata :refer :all]))
+
+(get-thing-shadow :thing-name "MyThing")
+```
 
 ###Kinesis
 ```clj

--- a/src/amazonica/aws/iot.clj
+++ b/src/amazonica/aws/iot.clj
@@ -1,0 +1,5 @@
+(ns amazonica.aws.iot
+  (:require [amazonica.core :as amz])
+  (:import [com.amazonaws.services.iot AWSIotClient]))
+
+(amz/set-client AWSIotClient *ns*)

--- a/src/amazonica/aws/iotdata.clj
+++ b/src/amazonica/aws/iotdata.clj
@@ -1,0 +1,5 @@
+(ns amazonica.aws.iotdata
+  (:require [amazonica.core :as amz])
+  (:import [com.amazonaws.services.iotdata AWSIotDataClient]))
+
+(amz/set-client AWSIotDataClient *ns*)


### PR DESCRIPTION
Wasn't sure if there was a standard for how to name the data API, so I just followed the AWS SDK package structure.

There are also async clients which support returning a future or providing callback handlers. Wasn't sure if there was already support for a client like this, so I left it out.

Let me know if it's a requirement and I'll gladly add them.

Cheers!