### PR TITLE
.getParameterCount is only supported in JDK8 and upwards, 0.3.58 brok…

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -620,7 +620,7 @@
         type (.getName (.getReturnType method))]
     (or (and
           (.startsWith name "get")
-          (= 0 (.getParameterCount method)))
+          (= 0 (count (.getParameterTypes method))))
         (and
           (.startsWith name "is")
           (= "boolean" type)))))


### PR DESCRIPTION
…e support for older Java versions

- Amended to count `.getParameterTypes` as is done across project

https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Method.html#getParameterCount--

Is not supported in older versions of Java which would mean the fix made for 0.3.58 would be a breaking change. I've amended the code to reflect the same method called to count parameters accepted in methods across the project. This should fix support for 1.6/1.7. Thanks to @ragnard for spotting.