### PR TITLE
Bumped kinesis dependency version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/algo.generic "0.1.2"]
                  [com.amazonaws/aws-java-sdk "1.11.20" :exclusions [joda-time]]
-                 [com.amazonaws/amazon-kinesis-client "1.6.3" :exclusions [joda-time]]
+                 [com.amazonaws/amazon-kinesis-client "1.6.5" :exclusions [joda-time]]
                  [joda-time "2.8.1"]
                  [robert/hooke "1.3.0"]
                  [com.taoensso/nippy "2.7.0"]])


### PR DESCRIPTION
Bumped the kinesis version as there seems to be an issue writing cloudwatch metrics with the later version of aws sdk.