### PR TITLE
adding support for kms-key-id for SSE in s3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amazonica "0.3.76"
+(defproject amazonica "0.3.77"
   :description "A comprehensive Clojure client for the entire Amazon AWS api."
   :url "https://github.com/mcohen01/amazonica"
   :license {:name "Eclipse Public License"

--- a/src/amazonica/aws/s3.clj
+++ b/src/amazonica/aws/s3.clj
@@ -106,6 +106,7 @@
      ;; :raw-metadata            (.getRawMetadata obj)
      :restore-expiration-time (marshall (.getRestoreExpirationTime obj))
      :server-side-encryption  (.getServerSideEncryption obj)
+     :server-side-encryption-aws-kms-key-id (.getSSEAwsKmsKeyId obj)
      :user-metadata           (marshall (.getUserMetadata obj))
      :version-id              (.getVersionId obj)})
   S3Object
@@ -149,6 +150,8 @@
         (.setRestoreExpirationTime om (to-date rt)))
       (when-let [sse (:server-side-encryption col)]
         (.setServerSideEncryption om sse))
+      (when-let [sse-kms-key-id (:server-side-encryption-aws-kms-key-id col)]
+        (.setHeader om "x-amz-server-side-encryption-aws-kms-key-id" sse-kms-key-id))
       (when-let [metadata (:user-metadata col)]
         (doseq [[k v] metadata]
           (.addUserMetadata om


### PR DESCRIPTION
For some strange and unknown reason, the AWS SDK does not allow setting of the kms-id via the ObjectMetadata class (though it does in the Android version of the SDK). Weirder is that it allows getting of it!

I am therefore adding support of this here via the generic .setHeader method....