### PR TITLE
exclude clojure.core/get-method from apigateway

### DIFF
--- a/src/amazonica/aws/apigateway.clj
+++ b/src/amazonica/aws/apigateway.clj
@@ -1,4 +1,5 @@
 (ns amazonica.aws.apigateway
+  (:refer-clojure :exclude [get-method])
   (:require [amazonica.core :as amz])
   (:import com.amazonaws.services.apigateway.AmazonApiGatewayClient))
 

--- a/test/amazonica/test/apigateway.clj
+++ b/test/amazonica/test/apigateway.clj
@@ -1,0 +1,31 @@
+(ns amazonica.test.apigateway
+  (:refer-clojure :exclude [get-method])
+  (:use [clojure.test]
+        [clojure.set]
+        [amazonica.aws.apigateway]))
+
+(def cred
+  (let [access "aws_access_key_id"
+        secret "aws_secret_access_key"
+        file   "/.aws/credentials"
+        creds  (-> "user.home"
+                   System/getProperty
+                   (str file)
+                   slurp
+                   (.split "\n"))]
+    (clojure.set/rename-keys
+      (reduce
+        (fn [m e]
+          (let [pair (.split e "=")]
+            (if (some #{access secret} [(first pair)])
+                (apply assoc m pair)
+                m)))
+        {}
+        creds)
+      {access :access-key secret :secret-key})))
+
+(deftest apigateway []
+
+  (get-rest-apis cred)
+
+)


### PR DESCRIPTION
Avoid getting this warning each time I use apigateway : 

> WARNING: get-method already refers to: #'clojure.core/get-method in namespace: amazonica.aws.apigateway, being replaced by: #'amazonica.aws.apigateway/get-method
