### PR TITLE
Add client class to namespace

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -941,5 +941,6 @@
    from the Amazon*Client class as Clojure functions."
   [client ns]
   (show-functions ns)
+  (intern ns 'client-class client)
   (doseq [[k v] (client-methods client)]
     (intern-function client ns k v)))


### PR DESCRIPTION
Make the client class consistently available on the namespace. This is useful for introspection without needing a specific var in the ns (since the value is going to be the same for all vars anyway).