### PR TITLE
Return accessors for all methods in aws-package.

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -653,14 +653,15 @@
   "Returns a vector of getters or setters for the class."
   [clazz getters?]
   (reduce
-    #(if (or
-           (and getters? (getter? %2))
-           (and (not getters?)
-                (.startsWith (.getName %2) "set")))
-      (conj % %2)
-      %)
+    #(if (and (aws-package? (.getDeclaringClass %2))
+              (or
+                (and getters? (getter? %2))
+                (and (not getters?)
+                     (.startsWith (.getName %2) "set"))))
+       (conj % %2)
+       %)
     []
-    (.getDeclaredMethods clazz)))
+    (.getMethods clazz)))
 
 (defn- prop->name
   [method]

--- a/test/amazonica/test/s3.clj
+++ b/test/amazonica/test/s3.clj
@@ -19,24 +19,11 @@
         [amazonica.aws.s3]))
 
 (def cred
-  (let [access "aws_access_key_id"
-        secret "aws_secret_access_key"
-        file   "/.aws/credentials"
-        creds  (-> "user.home"
-                   System/getProperty
-                   (str file)
-                   slurp
-                   (.split "\n"))]
-    (clojure.set/rename-keys 
-      (reduce
-        (fn [m e]
-          (let [pair (.split e "=")]
-            (if (some #{access secret} [(first pair)])
-                (apply assoc m pair)
-                m)))
-        {}
-        creds)
-      {access :access-key secret :secret-key})))
+  (let [file  (str (System/getProperty "user.home") "/.aws/credentials")
+        lines (clojure.string/split (slurp file) #"\n")
+        creds (into {} (filter second (map #(clojure.string/split % #"\s*=\s*") lines)))]
+    {:access-key (get creds "aws_access_key_id")
+     :secret-key (get creds "aws_secret_access_key")}))
 
 (deftest s3 []
 

--- a/test/amazonica/test/s3transfer.clj
+++ b/test/amazonica/test/s3transfer.clj
@@ -6,25 +6,11 @@
         [clojure.test]))
 
 (def cred
-  (let [access "aws_access_key_id"
-        secret "aws_secret_access_key"
-        file   "/.aws/credentials"
-        creds  (-> "user.home"
-                   System/getProperty
-                   (str file)
-                   slurp
-                   (.split "\n"))]
-    (clojure.set/rename-keys 
-      (reduce
-        (fn [m e]
-          (let [pair (.split e "=")]
-            (if (some #{access secret} [(first pair)])
-                (apply assoc m pair)
-                m)))
-        {}
-        creds)
-      {access :access-key secret :secret-key})))
-
+  (let [file  (str (System/getProperty "user.home") "/.aws/credentials")
+        lines (clojure.string/split (slurp file) #"\n")
+        creds (into {} (filter second (map #(clojure.string/split % #"\s*=\s*") lines)))]
+    {:access-key (get creds "aws_access_key_id")
+     :secret-key (get creds "aws_secret_access_key")}))
 
 (deftest s3transfer []
 


### PR DESCRIPTION
Allows accessors in aws service namespace to be picked up properly.

Fix #270