### PR TITLE
Add optional `dynamodb-endpoint` field to worker

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amazonica "0.3.89"
+(defproject amazonica "0.3.90-SNAPSHOT"
   :description "A comprehensive Clojure client for the entire Amazon AWS api."
   :url "https://github.com/mcohen01/amazonica"
   :license {:name "Eclipse Public License"
@@ -10,7 +10,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/algo.generic "0.1.2"]
                  [com.amazonaws/aws-java-sdk "1.11.98" :exclusions [joda-time]]
-                 [com.amazonaws/amazon-kinesis-client "1.6.5" :exclusions [joda-time]]
+                 [com.amazonaws/amazon-kinesis-client "1.7.4" :exclusions [joda-time]]
                  [joda-time "2.9.6"]
                  [robert/hooke "1.3.0"]
                  [com.taoensso/nippy "2.12.2"]])

--- a/src/amazonica/aws/kinesis.clj
+++ b/src/amazonica/aws/kinesis.clj
@@ -20,12 +20,11 @@
               KinesisClientLibDependencyException
               ShutdownException
               ThrottlingException]
-           [com.amazonaws.services.kinesis.clientlibrary.types
-            ShutdownReason]
            [com.amazonaws.services.kinesis.clientlibrary.lib.worker
               InitialPositionInStream
               KinesisClientLibConfiguration
-              Worker]
+              Worker
+              ShutdownReason]
            java.nio.ByteBuffer
            java.util.UUID))
 
@@ -142,6 +141,7 @@
            stream
            worker-id
            endpoint
+           dynamodb-endpoint
            initial-position-in-stream
            failover-time-millis
            shard-sync-interval-millis
@@ -171,6 +171,9 @@
 
           endpoint
           (.withKinesisEndpoint endpoint)
+
+          dynamodb-endpoint
+          (.withDynamoDBEndpoint dynamodb-endpoint)
 
           initial-position-in-stream
           (.withInitialPositionInStream


### PR DESCRIPTION
A desirable option, when working with local tools such as [Dynalite](https://github.com/mhart/dynalite) and [Kinesalite](https://github.com/mhart/kinesalite), is to change the configured endpoint. KCL enables this via [withDynamoDBEndpoint](https://github.com/awslabs/amazon-kinesis-client/blob/master/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java#L734).

This change required an update to KCL. I've run the tests and they pass.

An alternative solution would be a different version of the `worker` function which uses [this constructor](https://github.com/awslabs/amazon-kinesis-client/blob/master/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/Worker.java#L174) - allowing the caller to explicitly create and pass Kinesis, DynamoDB and CloudWatch clients.