### PR TITLE
Adding withTimestampAtInitialPosistion as worker setting

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amazonica "0.3.90"
+(defproject amazonica "0.3.91-SNAPSHOT"
   :description "A comprehensive Clojure client for the entire Amazon AWS api."
   :url "https://github.com/mcohen01/amazonica"
   :license {:name "Eclipse Public License"

--- a/src/amazonica/aws/kinesis.clj
+++ b/src/amazonica/aws/kinesis.clj
@@ -25,6 +25,8 @@
               KinesisClientLibConfiguration
               Worker
               ShutdownReason]
+           [com.amazonaws.services.kinesis.metrics.interfaces
+            MetricsLevel]
            java.nio.ByteBuffer
            java.util.UUID))
 
@@ -157,6 +159,7 @@
            cloud-watch-client-config
            user-agent
            task-backoff-time-millis
+           metrics-level
            metrics-buffer-time-millis
            metrics-max-queue-size
            validate-sequence-number-before-checkpointing
@@ -225,6 +228,9 @@
 
           task-backoff-time-millis
           (.withTaskBackoffTimeMillis task-backoff-time-millis)
+
+          metrics-level
+          (.withMetricsLevel (MetricsLevel/valueOf (name metrics-level)))
 
           metrics-buffer-time-millis
           (.withMetricsBufferTimeMillis metrics-buffer-time-millis)

--- a/src/amazonica/aws/kinesis.clj
+++ b/src/amazonica/aws/kinesis.clj
@@ -143,6 +143,7 @@
            endpoint
            dynamodb-endpoint
            initial-position-in-stream
+           ^java.util.Date initial-position-in-stream-date
            failover-time-millis
            shard-sync-interval-millis
            max-records
@@ -178,6 +179,10 @@
           initial-position-in-stream
           (.withInitialPositionInStream
            (InitialPositionInStream/valueOf (name initial-position-in-stream)))
+
+          initial-position-in-stream-date
+          (.withTimestampAtInitialPositionInStream
+           initial-position-in-stream-date)
 
           failover-time-millis
           (.withFailoverTimeMillis failover-time-millis)


### PR DESCRIPTION
Adding the ability to use withTimestamp as the initial position in the stream.

Adding the ability to set the metrics level, in testing it's handy to be able to just turn them off, :NONE.