### PR TITLE
Convert LogConfiguration options to the string-keyed map it expects

### DIFF
--- a/src/amazonica/aws/ecs.clj
+++ b/src/amazonica/aws/ecs.clj
@@ -1,5 +1,15 @@
 (ns amazonica.aws.ecs
-  (:require [amazonica.core :as amz])
-  (:import [com.amazonaws.services.ecs AmazonECSClient]))
+  (:require [amazonica.core :as amz]
+            [clojure.walk :as walk])
+  (:import [com.amazonaws.services.ecs AmazonECSClient]
+           (com.amazonaws.services.ecs.model LogConfiguration)))
 
 (amz/set-client AmazonECSClient *ns*)
+
+(amz/register-coercions
+  LogConfiguration
+  (fn [value]
+    (doto (LogConfiguration.)
+      (.setLogDriver (:log-driver value))
+      (.setOptions (walk/stringify-keys (:options value))))))
+


### PR DESCRIPTION
Hello.

Thanks for maintaining Amazonica.  It is super useful!

I've run into a bug where ECS task definitions with log configuration options won't round-trip.

This used to work...

```clojure
(defn update-task-definition!
  "Update a cluster's task to use a new app docker container.
  Returns settings updated with the new task definition's ARN"
  [{:keys [::task-arn ::repository ::tag] :as settings}]
  (log/info (str "Updating task definition to tag " tag " ..."))
  (let [definition (fetch-task-definition task-arn)
        new-definition-arn (-> definition
                               (assoc-in [:container-definitions 0 :image] (str repository ":" tag))
                               (ecs/register-task-definition :family (:family definition))
                               (get-in [:task-definition :task-definition-arn]))]
    (log/info (str "Updated task definition to " new-definition-arn " ."))
    (assoc settings ::new-task-definition-arn new-definition-arn)))

```

... until I added a log configuration to my task.

Then it started blowing up with:
```
ClassCastException clojure.lang.Keyword cannot be cast to java.lang.String  com.amazonaws.protocol.json.internal.SimpleTypeJsonMarshallers$13.marshall (SimpleTypeJsonMarshallers.java:145)
```

Apparently the log configuration options keys get keywordized on the way from Amazon, but don't get stringified on the way back.

I'm not sure there isn't a more correct way to fix this, but registering a coercion for com.amazonaws.services.ecs.model.LogConfiguration seems to work.