### PR TITLE
Add support for the dynamoDB streams adaptor client

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amazonica "0.3.96"
+(defproject amazonica "0.3.97-SNAPSHOT"
   :description "A comprehensive Clojure client for the entire Amazon AWS api."
   :url "https://github.com/mcohen01/amazonica"
   :license {:name "Eclipse Public License"
@@ -11,6 +11,7 @@
                  [org.clojure/algo.generic "0.1.2"]
                  [com.amazonaws/aws-java-sdk "1.11.109" :exclusions [joda-time]]
                  [com.amazonaws/amazon-kinesis-client "1.7.4" :exclusions [joda-time]]
+                 [com.amazonaws/dynamodb-streams-kinesis-adapter "1.2.1" :exclusions [joda-time]]
                  [joda-time "2.9.6"]
                  [robert/hooke "1.3.0"]
                  [com.taoensso/nippy "2.12.2"]])


### PR DESCRIPTION
At the moment it is not possible to use the kinesis client library and Amazonica to consume a stream of events from a DynamoDB table. This is because when the kinesis worker is created a AmazonDynamoDBStreamsAdapterClient object needs to be constructed and passed into the kinesis worker constructor.

This patch adds a new flag dynamodb-adaptor-client? to Amazonica, which gets Amazonica to automatically create the AmazonDynamoDBStreamsAdapterClient object.

The patch is currently missing a test - plan to add this once I have feedback on whether the patch looks good.
