### PR TITLE
Support sending binary data over SNS

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject amazonica "0.3.102"
+(defproject amazonica "0.3.103-SNAPSHOT"
   :description "A comprehensive Clojure client for the entire Amazon AWS api."
   :url "https://github.com/mcohen01/amazonica"
   :license {:name "Eclipse Public License"

--- a/src/amazonica/aws/sns.clj
+++ b/src/amazonica/aws/sns.clj
@@ -1,7 +1,8 @@
 (ns amazonica.aws.sns
   (:require [amazonica.core :as amz])
   (:import com.amazonaws.services.sns.AmazonSNSClient
-           [com.amazonaws.services.sns.model MessageAttributeValue]))
+           [com.amazonaws.services.sns.model MessageAttributeValue]
+           [java.nio ByteBuffer]))
 
 (amz/register-coercions
   MessageAttributeValue
@@ -9,6 +10,7 @@
     (cond
       (string? value) (doto (MessageAttributeValue.) (.withDataType "String") (.withStringValue value))
       (number? value) (doto (MessageAttributeValue.) (.withDataType "Number") (.withStringValue (str value)))
+      (instance? ByteBuffer value) (doto (MessageAttributeValue.) (.withDataType "Binary") (.withBinaryValue value))
       :else (throw (ex-info
                      (format "Values of type %s are not supported for SNS Message Attributes" (class value))
                      {:value value})))))


### PR DESCRIPTION
SNS Supports sending Binary Data over SNS, but Amazonica does not support this. Now if you provide a ByteBuffer as a value in your MessageAttributes map, it will send it as Binary.