### PR TITLE
Add `get-object-metadata` example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1082,7 +1082,7 @@ To put metric data.   [UnitTypes](http://docs.aws.amazon.com/AmazonCloudWatch/la
 ;; if no :credentials key is provided the default authentication scheme is used (preferable),
 ;; see the [Authentication] #(authentication) section above
 
-;; if no :dynamodb-adaptor-client? is provided, then it defaults to not using the 
+;; if no :dynamodb-adaptor-client? is provided, then it defaults to not using the
 ;; DynamoDB Streams Kinesis Adaptor. Set this flag to true when consuming streams
 ;; from DynamoDB
 
@@ -1328,6 +1328,10 @@ To put metric data.   [UnitTypes](http://docs.aws.amazon.com/AmazonCloudWatch/la
 
 ;; get tags for the bucket
 (get-bucket-tagging-configuration {:bucket-name bucket})
+
+;; get just object metadata, e.g. content-length without fetching content:
+(get-object-metadata :bucket-name bucket1
+                     :key "foo")
 
 ;; put object from stream
 (def some-bytes (.getBytes "Amazonica" "UTF-8"))


### PR DESCRIPTION
I was having trouble with getting object length without fetching it, so decided that example in readme would be usefull. Was not sure about test for this method, but may be will add it later. 


[getObjectMetadata](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3Client.html#getObjectMetadata-java.lang.String-java.lang.String-)
 