### PR TITLE
Attach :arglists metadata to vars interned by intern-function

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -951,7 +951,9 @@
   (let [parameters (. method getParameters)
         names (map parameter-clojure-name parameters)
         ;; This will help determine when parameter names should be
-        ;; suffixed with an index i.e. `parameter-1`.
+        ;; suffixed with an index i.e. `parameter-1`. Suffixing is
+        ;; necessary when parameter names are synthesized from their
+        ;; type names and the likelihood duplicates is high.
         name-frequency (frequencies names)]
     (loop [names (map parameter-clojure-name parameters)
            ;; This map keeps track of the index of names when they

--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -925,18 +925,17 @@
   "Given a `java.lang.reflect.Parameter` return it's name in kabob
   case."
   [parameter]
-  (let [name (. parameter getName)
-        name (if (re-matches #"arg\d+" name)
-               ;; The name was most likely synthesized so we derive
-               ;; it's name from it's type.
+  (let [name (if (. parameter isNamePresent)
+               (. parameter getName)
+               ;; The name will be synthesized so instead we'll derive
+               ;; it from it's type.
                (let [type (. parameter getType)
                      type-name (last (.. type getName (split "\\.")))
                      type-name (if-let [;; Check for a type name like "[C" etc. 
                                         [_ name] (re-matches #"\[([A-Z]+)$" type-name)]
                                  name
                                  type-name)]
-                 type-name)
-               name)]
+                 type-name))]
     (-> name
         ;; Replace the space between a non-upper-case letter and an
         ;; upper-case letter with a dash.

--- a/test/amazonica/test/core.clj
+++ b/test/amazonica/test/core.clj
@@ -127,18 +127,28 @@
     (is (some? old) (str "missing old var: " service " " old-name))
     (is (some? new) (str "missing new var: " service " " new-name))
 
-    (is (= #{:ns
+    (is (= #{:arglists
+             :ns
              :name
              :amazonica/client
              :amazonica/methods
              :amazonica/deprecated-in-favor-of}
            (set (keys (meta old)))))
-    (is (= #{:ns :name :amazonica/client :amazonica/methods}
+    (is (= #{:arglists
+             :ns
+             :name
+             :amazonica/client
+             :amazonica/methods}
            (set (keys (meta new)))))
-    (is (= new (-> old meta :amazonica/deprecated-in-favor-of))))
+    (is (= new
+           (get (meta old) :amazonica/deprecated-in-favor-of))))
 
   ;; Make sure we don't accidentally attach new metadata keys to old, untouched
   ;; vars:
   (let [unrelated-var #'amazonica.aws.ec2/describe-addresses]
     (is (= (set (keys (meta unrelated-var)))
-           #{:ns :name :amazonica/client :amazonica/methods}))))
+           #{:arglists
+             :name
+             :ns
+             :amazonica/client
+             :amazonica/methods}))))


### PR DESCRIPTION
This somewhat addresses considerations and suggestions made in #170. Without going into too much detail, we can retrieve information from [`java.lang.reflect.Parameter`s](https://docs.oracle.com/javase/8/docs/api/java/lang/reflect/Parameter.html) which we can use to derive a decent parameter vector for `:arglists` meta data.

Here's an example:

```clj
(ns scratch
  (:require [amazonica.aws.s3 :as aws.s3]))

(:arglists (meta #'aws.s3/get-object))
;; => ([get-object-request] [get-object-request file] [string-1 string-2])
```

I'll admit it may not be as thorough a derivation as via "referencing the JSON models at compile time" but I think it suffices as an intermediate solution for now. If the AWS JDK library retains parameter names in the class files in the future, I think this patch will work out nicely for that. In either case it's certainly a step up even if it's a small one.

There are notes in the code which explain in a bit more detail how the `:arglists` data are derived. Let me know what else I can do to make this amenable to merge.
