### PR TITLE
Update `com.amazonaws/aws-java-sdk` version (Issue #327)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,7 +9,7 @@
   :deploy-repositories [["releases" :clojars]]
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/algo.generic "0.1.2"]
-                 [com.amazonaws/aws-java-sdk "1.11.155" :exclusions [joda-time]]
+                 [com.amazonaws/aws-java-sdk "1.11.166" :exclusions [joda-time]]
                  [com.amazonaws/amazon-kinesis-client "1.7.5" :exclusions [joda-time]]
                  [com.amazonaws/dynamodb-streams-kinesis-adapter "1.2.1"
                   :exclusions [com.amazonaws/amazon-kinesis-client


### PR DESCRIPTION
Proposed change to update version to "1.11.166" from "1.11.155". I have not tested this change, but it's a minor version upgrade to support the eu-west-2 region name.