### PR TITLE
[kinesis] Allow fully manual checkpointing

### DIFF
--- a/src/amazonica/aws/kinesis.clj
+++ b/src/amazonica/aws/kinesis.clj
@@ -147,12 +147,12 @@
                           (vec (seq records)))))
             (if (or (processor (functor/fmap (partial marshall deserializer)
                                              (vec (seq records))))
-                    (and checkpoint
+                    (and checkpoint-timeout
                          (> (System/currentTimeMillis) @next-check)))
-              (do (if checkpoint
+              (do (if checkpoint-timeout
                     (reset! next-check
                             (+' (System/currentTimeMillis)
-                                (*' 1000 checkpoint))))
+                                (*' 1000 checkpoint-timeout))))
                   (some (partial mark-checkpoint checkpointer) [1 2 3 4 5])))))))))
 
 (defn- kinesis-client-lib-configuration


### PR DESCRIPTION
For my use case, neither checkpointing every n seconds nor checkpointing by returning `true` from the processing function is fine-grained enough. I suggest the changes in this PR. Note that I haven't tested this code - wanted to see whether you're open to this change before I spend any actual time on it.