### PR TITLE
Update node runtime based on amazon error

### DIFF
--- a/src/amazonica/aws/lambda.clj
+++ b/src/amazonica/aws/lambda.clj
@@ -29,7 +29,7 @@
         attrs   (merge {:timeout 10
                         :memory-size 256
                         :mode "event"
-                        :runtime "nodejs"
+                        :runtime "nodejs6.10"
                         :description "uploaded via amazonica"} attrs)
         fn-name (or (:function-name attrs) (function-name (:function attrs)))
         attrs   (if (:function attrs)


### PR DESCRIPTION
Before this change, the code would throw the following error:

>The runtime parameter of nodejs is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs6.10) while creating or updating functions.