### PR TITLE
Add coercion for cognito AttributeType

### DIFF
--- a/src/amazonica/aws/cognitoidp.clj
+++ b/src/amazonica/aws/cognitoidp.clj
@@ -1,5 +1,12 @@
 (ns amazonica.aws.cognitoidp
   (:require [amazonica.core :as amz])
-  (:import [com.amazonaws.services.cognitoidp AWSCognitoIdentityProviderClient]))
+  (:import [com.amazonaws.services.cognitoidp AWSCognitoIdentityProviderClient]
+           [com.amazonaws.services.cognitoidp.model AttributeType]))
+
+(amz/register-coercions AttributeType
+  (fn [[n v]]
+    (-> (AttributeType.)
+        (.withName n)
+        (.withValue v))))
 
 (amz/set-client AWSCognitoIdentityProviderClient *ns*)


### PR DESCRIPTION
The `admin-create-user` function in Cognito (aka AdminCreateUser) has a setter for user attributes. There are two arities, one for varargs and one that takes a list, but in either case the thing that is passed is one or more AttributeType objects. Those are not coerced by amazonica, and this PR adds one way of doing so.

With this code in place, a caller of `admin-create-user` should pass user attributes as a list of pairs, for example:

```clojure
(require '[amazonica.aws.cognitoidp :as idp])
(let [cognito {:pool-id "blah-some-example-pool-id"}
      phone "+12125551212"]
  (idp/admin-create-user :user-pool-id (:pool-id cognito)
                         :temporary-password "112233"
                         :username phone
                         :user-attributes [["phone_number" phone]]))
```

It's not perfect - I'd prefer if ALL the user attributes could be combined into a single map. In fact I'm mildly surprised that the code as written doesn't work with a map, because of how maps are seqable, but I guess it has something to do with how amazonica is written. That's something that could potentially be changed, but I didn't bother this time.