### PR TITLE
remove reflection warnings

### DIFF
--- a/src/amazonica/aws/cloudsearchdomain.clj
+++ b/src/amazonica/aws/cloudsearchdomain.clj
@@ -1,10 +1,11 @@
 (ns amazonica.aws.cloudsearchdomain
   (:require [amazonica.core :as amz])
-  (:import com.amazonaws.services.cloudsearchdomain.AmazonCloudSearchDomainClient))
+  (:import com.amazonaws.services.cloudsearchdomain.AmazonCloudSearchDomainClient
+           com.amazonaws.AmazonWebServiceClient))
 
 (amz/set-client AmazonCloudSearchDomainClient *ns*)
 
 (defn set-endpoint [& args]
   (.setEndpoint
-    (amz/candidate-client AmazonCloudSearchDomainClient args)
+    ^AmazonWebServiceClient (amz/candidate-client AmazonCloudSearchDomainClient args)
     (last args)))

--- a/src/amazonica/aws/dynamodbv2.clj
+++ b/src/amazonica/aws/dynamodbv2.clj
@@ -10,7 +10,8 @@
              AttributeValue
              KeysAndAttributes
              ProvisionedThroughput]
-           java.nio.ByteBuffer))
+           java.nio.ByteBuffer
+           java.lang.reflect.Method))
 
 (defn- parse-number
   [^String ns]
@@ -104,7 +105,7 @@
       pt)))
 
 (->> (.getMethods AmazonDynamoDBClient)
-     (filter #(= "setSignerRegionOverride" (.getName %)))
+     (filter #(= "setSignerRegionOverride" (.getName ^Method %)))
      (intern-function AmazonDynamoDBClient *ns* :set-signer-region-override))
 
 (set-client AmazonDynamoDBClient *ns*)

--- a/src/amazonica/aws/ec2.clj
+++ b/src/amazonica/aws/ec2.clj
@@ -4,7 +4,7 @@
            [com.amazonaws.services.ec2.model PortRange Tag]))
 
 (defn- key->str [kw]
-  (if (keyword? kw) 
+  (if (keyword? kw)
       (name kw)
       (str kw)))
 
@@ -28,8 +28,8 @@
       (cond
         (string? value)
         (do
-          (.setFrom ports (Integer. value))
-          (.setTo ports (Integer. value)))
+          (.setFrom ports (Integer. ^String value))
+          (.setTo ports (Integer. ^String value)))
         (number? value)
         (do
           (.setFrom ports (int value))

--- a/src/amazonica/aws/ecs.clj
+++ b/src/amazonica/aws/ecs.clj
@@ -2,7 +2,7 @@
   (:require [amazonica.core :as amz]
             [clojure.walk :as walk])
   (:import [com.amazonaws.services.ecs AmazonECSClient]
-           (com.amazonaws.services.ecs.model LogConfiguration)))
+           (com.amazonaws.services.ecs.model LogConfiguration LogDriver)))
 
 (amz/set-client AmazonECSClient *ns*)
 
@@ -10,6 +10,6 @@
   LogConfiguration
   (fn [value]
     (doto (LogConfiguration.)
-      (.setLogDriver (:log-driver value))
+      (.setLogDriver ^LogDriver (:log-driver value))
       (.setOptions (walk/stringify-keys (:options value))))))
 

--- a/src/amazonica/aws/glacier.clj
+++ b/src/amazonica/aws/glacier.clj
@@ -3,12 +3,12 @@
         [robert.hooke :only (add-hook)])
   (:import com.amazonaws.services.glacier.AmazonGlacierClient
            amazonica.TreeHash
-           [java.io BufferedInputStream FileInputStream]))
+           [java.io File BufferedInputStream FileInputStream]))
 
 (set-client AmazonGlacierClient *ns*)
 
 (defn- file-hash->map
-  [file]
+  [^File file]
   {:content-length (.length file)
    :checksum       (-> file
                        TreeHash/computeSHA256TreeHash

--- a/src/amazonica/aws/lambda.clj
+++ b/src/amazonica/aws/lambda.clj
@@ -5,7 +5,7 @@
 
 (amz/set-client AWSLambdaClient *ns*)
 
-(defn byte-buffer-zip-file [function-name body]
+(defn byte-buffer-zip-file [function-name ^String body]
   (let [baos (java.io.ByteArrayOutputStream.)
         zos  (java.util.zip.ZipOutputStream. baos)]
     (.putNextEntry zos (java.util.zip.ZipEntry. (str function-name ".js")))
@@ -15,7 +15,7 @@
     (java.nio.ByteBuffer/wrap (.toByteArray baos))))
 
 (defn function-name [node-fn]
-  (-> (re-find #"exports\..+=" node-fn)
+  (-> ^String (re-find #"exports\..+=" node-fn)
       (.replaceFirst "exports." "")
       (.replaceFirst "=" "")
       .trim))

--- a/src/amazonica/aws/opsworks.clj
+++ b/src/amazonica/aws/opsworks.clj
@@ -1,13 +1,14 @@
 (ns amazonica.aws.opsworks
   (:require [amazonica.core :as amz])
   (:import com.amazonaws.services.opsworks.AWSOpsWorksClient
-           com.amazonaws.services.opsworks.model.DeploymentCommand))
+           com.amazonaws.services.opsworks.model.DeploymentCommand
+           com.amazonaws.services.opsworks.model.DeploymentCommandName))
 
 (amz/register-coercions
   DeploymentCommand
   (fn [value]
     (doto (DeploymentCommand.)
-      (.setName (:name value))
+      (.setName ^DeploymentCommandName (:name value))
       (.setArgs (:args value)))))
 
 (amz/set-client AWSOpsWorksClient *ns*)

--- a/src/amazonica/aws/sqs.clj
+++ b/src/amazonica/aws/sqs.clj
@@ -61,14 +61,16 @@
 (add-hook #'receive-message #'delete-on-receive)
 
 (defn find-queue [& s]
-  (some #(if (.contains % (or (second s) (first s))) %)
-        (:queue-urls (list-queues (first s)))))
+  (some
+    (fn [^String q]
+      (when (.contains q (or (second s) (first s))) q))
+    (:queue-urls (list-queues (first s)))))
 
 (defn arn [q] (-> q get-queue-attributes :QueueArn))
 
 (defn assign-dead-letter-queue
   [queue dlq max-receive-count]
   (set-queue-attributes
-    queue {"RedrivePolicy" 
+    queue {"RedrivePolicy"
            (str "{\"maxReceiveCount\": " max-receive-count ",
                   \"deadLetterTargetArn\": \"" (arn dlq) "\"}")}))

--- a/test/amazonica/test/securitytoken.clj
+++ b/test/amazonica/test/securitytoken.clj
@@ -1,7 +1,7 @@
 (ns amazonica.test.securitytoken
   (:use [clojure.test]
-        [amazonica.aws.identitymanagement :exclude [show-functions waiters client-class]]
-        [amazonica.aws.s3 :exclude [show-functions client-class]]
+        [amazonica.aws.identitymanagement :exclude [show-functions waiters client-class get-cached-response-metadata]]
+        [amazonica.aws.s3 :exclude [show-functions client-class get-cached-response-metadata]]
         [amazonica.aws.securitytoken :exclude [show-functions waiters client-class]]))
 
 (deftest securitytoken []


### PR DESCRIPTION
Fix #155 

Doesn't seem to be so bad in terms of readability. In certain cases, I think it gives more context to understand what the code is doing (with the exception of the `cond->` that possibly reads worse). I was also concerned about seeing my own reflection warnings than those of Amazonica (more than performance issues). Thanks for the lib.