### PR TITLE
Fix namespace typo in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,7 +623,7 @@ To put metric data.   [UnitTypes](http://docs.aws.amazon.com/AmazonCloudWatch/la
 ### CognitoIdentityProviders
 ```clj
 (ns com.example
-  (:require [amazaonica.aws.cognitoidp :refer :all]))
+  (:require [amazonica.aws.cognitoidp :refer :all]))
 
 (list-user-pools {:max-results 2})
 => {:user-pools [{:lambda-config {}, :last-modified-date "2017-06-16T14:16:28.950-03:00"], :creation-date "2017-06-15T16:23:04.555-03:00"], :name "Amazonica", :id "us-west-1_example"}]}
@@ -633,7 +633,7 @@ To put metric data.   [UnitTypes](http://docs.aws.amazon.com/AmazonCloudWatch/la
 ### Comprehend
 ```clj
 (ns com.example
-(:require [amazaonica.aws.comprehend :refer :all]))
+(:require [amazonica.aws.comprehend :refer :all]))
 
 (amazonica.aws.comprehend/detect-entities {:language-code "en" :text "Hi my name is Joe Bloggs and I live in Glasgow, Scotland"})
 => {:entities [{:type "PERSON", :text "Joe Bloggs", :score 0.99758613, :begin-offset 14, :end-offset 24} {:type "LOCATION", :text "Glasgow, Scotland", :score 0.93267196, :begin-offset 39, :end-offset 56}]}


### PR DESCRIPTION
amazaonica -> amazonica