### PR TITLE
Add support for credentials_process in ~/.aws/credentials file

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -1,19 +1,15 @@
 (ns amazonica.core
   "Amazon AWS functions."
   (:use [clojure.algo.generic.functor :only (fmap)])
-  (:require [clojure.string :as str])
+  (:require [clojure.string :as str]
+            [amazonica.credentials :as creds])
   (:import clojure.lang.Reflector
            [com.amazonaws
              AmazonServiceException
              ClientConfiguration]
            [com.amazonaws.auth
              AWSCredentials
-             AWSCredentialsProvider
-             AWSStaticCredentialsProvider
-             BasicAWSCredentials
-             BasicSessionCredentials
-             DefaultAWSCredentialsProviderChain]
-           com.amazonaws.auth.profile.ProfileCredentialsProvider
+             AWSCredentialsProvider]
            [com.amazonaws.regions
              Region
              Regions]
@@ -178,35 +174,8 @@
                       raw-creds {})])
     (build-client clazz credentials configuration raw-creds options)))
 
-(defn get-credentials ^AWSCredentialsProvider
-  [credentials]
-  (cond
-    (instance? AWSCredentialsProvider credentials)
-      credentials
-    (instance? AWSCredentials credentials)
-      (AWSStaticCredentialsProvider. credentials)
-    (and (associative? credentials)
-         (contains? credentials :session-token))
-    (AWSStaticCredentialsProvider.
-      (BasicSessionCredentials.
-        (:access-key credentials)
-        (:secret-key credentials)
-        (:session-token credentials)))
-    (and (associative? credentials)
-         (contains? credentials :access-key))
-    (AWSStaticCredentialsProvider.
-      (BasicAWSCredentials.
-        (:access-key credentials)
-        (:secret-key credentials)))
-    (and (associative? credentials)
-         (contains? credentials :profile))
-    (ProfileCredentialsProvider.
-        (:profile credentials))
-    (and (associative? credentials)
-         (instance? AWSCredentialsProvider (:cred credentials)))
-    (:cred credentials)
-    :else
-    (DefaultAWSCredentialsProviderChain.)))
+(def get-credentials
+  creds/get-credentials)
 
 (defn parse-args
   "Legacy support means credentials may or may not be passed

--- a/src/amazonica/credentials.clj
+++ b/src/amazonica/credentials.clj
@@ -1,7 +1,6 @@
 (ns amazonica.credentials
   (:require [clojure.java.shell])
   (:import [com.amazonaws.auth.profile.internal
-            BasicProfileConfigLoader
             AwsProfileNameLoader]
            [com.amazonaws.auth.profile
             ProfilesConfigFile
@@ -15,7 +14,7 @@
             BasicSessionCredentials
             DefaultAWSCredentialsProviderChain
             EC2ContainerCredentialsProviderWrapper
-            EnvironmentVariableCredentialsProvider            
+            EnvironmentVariableCredentialsProvider
             SystemPropertiesCredentialsProvider]))
 
 (defn load-profile-name []
@@ -53,10 +52,10 @@
                               SecretAccessKey
                               SessionToken)))
 
-(defn extended-profile-credentials-provider ^AWSCredentialsProvider
-  ([]
+(defn extended-profile-credentials-provider
+  (^AWSCredentialsProvider []
    (extended-profile-credentials-provider (load-profile-name)))
-  ([profile-name]
+  (^AWSCredentialsProvider [profile-name]
    (let [provider (ProfileCredentialsProvider. profile-name)]
      (reify AWSCredentialsProvider
        (getCredentials [_]
@@ -71,7 +70,7 @@
                ;; Re-throw, profile doesn't exist
                (throw e)))))))))
 
-(defn extended-default-credentials-provider-chain ^AWSCredentialsProvider []
+(defn extended-default-credentials-provider-chain ^AWSCredentialsProviderChain []
   ;; As in https://github.com/aws/aws-sdk-java/blob/34acb557b674b157d854d1e6d1d583256d8fefd1/aws-java-sdk-core/src/main/java/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.java
   (AWSCredentialsProviderChain.
    (java.util.ArrayList. [(EnvironmentVariableCredentialsProvider.)

--- a/src/amazonica/credentials.clj
+++ b/src/amazonica/credentials.clj
@@ -1,0 +1,116 @@
+(ns amazonica.credentials
+  (:require [clojure.java.shell])
+  (:import [com.amazonaws.auth.profile.internal
+            BasicProfileConfigLoader
+            AwsProfileNameLoader]
+           [com.amazonaws.auth.profile
+            ProfilesConfigFile
+            ProfileCredentialsProvider]
+           [com.amazonaws.auth
+            AWSCredentials
+            AWSCredentialsProvider
+            AWSCredentialsProviderChain
+            AWSStaticCredentialsProvider
+            BasicAWSCredentials
+            BasicSessionCredentials
+            DefaultAWSCredentialsProviderChain
+            EC2ContainerCredentialsProviderWrapper
+            EnvironmentVariableCredentialsProvider            
+            SystemPropertiesCredentialsProvider]))
+
+(defn load-profile-name []
+  ;; As in https://github.com/aws/aws-sdk-java/blob/05a142018a82825c680f7176b21fde064ff7b8ab/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/ProfileCredentialsProvider.java#L124
+  (.loadProfileName (AwsProfileNameLoader/INSTANCE)))
+
+(defn load-profile [profile-name]
+  ;; As in https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/ProfilesConfigFile.java#L177
+  (get (.getAllBasicProfiles (ProfilesConfigFile.)) profile-name))
+
+(defn get-credentials-process-cmd [profile]
+  ;; See https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
+  (get (.getProperties profile) "credential_process"))
+
+(defn run-credential-process-cmd [cmd]
+  (let [cmd (clojure.string/split cmd #" ")
+        {:keys [exit out err]} (apply clojure.java.shell/sh cmd)]
+    (if (zero? exit)
+      out
+      (throw (ex-info (str "Non-zero exit: " (pr-str err)) {})))))
+
+(defn parse-credentials-json [json]
+  ;; The credential json has a simple structure and we only need string values
+  ;; No need to include an extra dependency on a json parser
+  (apply hash-map (-> json
+                      (clojure.string/replace #"[}{,:\"]" "")
+                      (clojure.string/split #"\s+"))))
+
+(defn get-credentials-via-cmd [cmd]
+  (let [json (run-credential-process-cmd cmd)
+        credential-map (parse-credentials-json json)
+        {:strs [AccessKeyId SecretAccessKey SessionToken]} credential-map]
+    (assert (and AccessKeyId SecretAccessKey SessionToken))
+    (BasicSessionCredentials. AccessKeyId
+                              SecretAccessKey
+                              SessionToken)))
+
+(defn extended-profile-credentials-provider ^AWSCredentialsProvider
+  ([]
+   (extended-profile-credentials-provider (load-profile-name)))
+  ([profile-name]
+   (let [provider (ProfileCredentialsProvider. profile-name)]
+     (reify AWSCredentialsProvider
+       (getCredentials [_]
+         (try
+           (.getCredentials provider)
+           (catch com.amazonaws.SdkClientException e
+             (if-let [profile (load-profile profile-name)]
+               (if-let [cmd (get-credentials-process-cmd profile)]
+                 (get-credentials-via-cmd cmd)
+                 ;; Re-throw, there is no credential_process field either
+                 (throw e))
+               ;; Re-throw, profile doesn't exist
+               (throw e)))))))))
+
+(defn extended-default-credentials-provider-chain ^AWSCredentialsProvider []
+  ;; As in https://github.com/aws/aws-sdk-java/blob/34acb557b674b157d854d1e6d1d583256d8fefd1/aws-java-sdk-core/src/main/java/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.java
+  (AWSCredentialsProviderChain.
+   (java.util.ArrayList. [(EnvironmentVariableCredentialsProvider.)
+                          (SystemPropertiesCredentialsProvider.)
+                          (extended-profile-credentials-provider)
+                          (EC2ContainerCredentialsProviderWrapper.)])))
+
+(defn get-credentials ^AWSCredentialsProvider
+  [credentials]
+  (cond
+    (instance? AWSCredentialsProvider credentials)
+      credentials
+    (instance? AWSCredentials credentials)
+      (AWSStaticCredentialsProvider. credentials)
+    (and (associative? credentials)
+         (contains? credentials :session-token))
+    (AWSStaticCredentialsProvider.
+      (BasicSessionCredentials.
+        (:access-key credentials)
+        (:secret-key credentials)
+        (:session-token credentials)))
+    (and (associative? credentials)
+         (contains? credentials :access-key))
+    (AWSStaticCredentialsProvider.
+      (BasicAWSCredentials.
+        (:access-key credentials)
+        (:secret-key credentials)))
+    (and (associative? credentials)
+         (contains? credentials :profile))
+    (extended-profile-credentials-provider
+      (:profile credentials))
+    (and (associative? credentials)
+         (instance? AWSCredentialsProvider (:cred credentials)))
+    (:cred credentials)
+    :else
+    (extended-default-credentials-provider-chain)))
+
+
+(comment
+
+  (.getCredentials (extended-profile-credentials-provider))
+  )


### PR DESCRIPTION
Hi,

We are currently migrating away from hardcoded AWS tokens. Instead we want to us an identity provider everywhere [1]. This is a bit too much too explain here, but this process gets session credentials via a special directive to a proces under `credential_process` in the `~/.aws/credential_file` [2].

This feature is supported by the AWS cli tool, but not by the Java AWS sdk [3]. Therefore it is also not supported by Amazonica. I hope you will consider adding this functionality. I've extended the current implementation to support this feature and it should not affect existing users.

[1] E.g. https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers.html
[2] https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
[3] https://github.com/aws/aws-sdk-java-v2/issues/455