### PR TITLE
Resource groups

### DIFF
--- a/src/amazonica/aws/resourcegroups.clj
+++ b/src/amazonica/aws/resourcegroups.clj
@@ -1,0 +1,5 @@
+(ns amazonica.aws.resourcegroups
+  (:require [amazonica.core :as amz])
+  (:import com.amazonaws.services.resourcegroups.AWSResourceGroupsClient))
+
+(amz/set-client AWSResourceGroupsClient *ns*)

--- a/src/amazonica/aws/resourcegroupstaggingapi.clj
+++ b/src/amazonica/aws/resourcegroupstaggingapi.clj
@@ -1,0 +1,5 @@
+(ns amazonica.aws.resourcegroupstaggingapi
+  (:require [amazonica.core :as amz])
+  (:import com.amazonaws.services.resourcegroupstaggingapi.AWSResourceGroupsTaggingAPIClient))
+
+(amz/set-client AWSResourceGroupsTaggingAPIClient *ns*)


### PR DESCRIPTION
adds basic support for resourcegroups and resourcegroups tagging api

I've done basic testing via resourcegroupstaggingapi/get-resources 
and resourcegroups/list-groups, list-group-resources, get-group, get-tags with success (due to your awesome use of reflection making this add trivial)