### PR TITLE
Fix queue name matching in find-queue...

### DIFF
--- a/src/amazonica/aws/sqs.clj
+++ b/src/amazonica/aws/sqs.clj
@@ -1,5 +1,6 @@
 (ns amazonica.aws.sqs
   (:use [amazonica.core :only (kw->str parse-args)]
+        [clojure.string :only (ends-with?)]
         [clojure.walk :only (stringify-keys)]
         [robert.hooke :only (add-hook)])
   (:import com.amazonaws.services.sqs.AmazonSQSClient))
@@ -67,7 +68,7 @@
 (defn find-queue [& s]
   (some
     (fn [^String q]
-      (when (.contains q (or (second s) (first s))) q))
+      (when (ends-with? q (or (second s) (first s))) q))
     (:queue-urls (list-queues (first s)))))
 
 (defn arn [q] (-> q get-queue-attributes :QueueArn))


### PR DESCRIPTION
This function was checking if a substring is contained within the queue URL. If
'z' was passed to find-queue it would match the word 'amazon' in the base URL of the queue, which matches all queue URLs – surely not what we want!

Only return a result if queue URL ends with the full queue name.