### PR TITLE
add support for using java.time instead of joda time

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -35,7 +35,8 @@
            java.nio.ByteBuffer
            java.text.ParsePosition
            java.text.SimpleDateFormat
-           java.util.Date))
+           java.util.Date
+           java.time.Instant))
 
 (defonce ^:private credential (atom {}))
 
@@ -321,6 +322,7 @@
   [date]
   (cond
     (instance? java.util.Date date) date
+    (instance? Instant date) (java.util.Date/from date)
     (instance? AbstractInstant date) (.toDate ^AbstractInstant date)
     (integer? date) (java.util.Date. (int date))
     true (.. (SimpleDateFormat. @date-format)
@@ -743,6 +745,11 @@
     (if (aws-package? (class obj))
         (get-fields obj)
         obj)))
+
+(defn marshall-date-to-java-time! []
+  (extend-protocol IMarshall 
+    java.util.Date
+    (marshall [obj] (.toInstant obj))))
 
 (defn- use-aws-request-bean?
   [^Method method args]


### PR DESCRIPTION
I'd rather not have joda dependency but I'm assuming here you'd rather have these changes as an opt-in