### PR TITLE
Allow billingMode to be set on Kinesis consumer

### DIFF
--- a/src/amazonica/aws/kinesis.clj
+++ b/src/amazonica/aws/kinesis.clj
@@ -161,6 +161,7 @@
            worker-id
            endpoint
            dynamodb-endpoint
+           billing-mode
            initial-position-in-stream
            ^java.util.Date initial-position-in-stream-date
            failover-time-millis
@@ -195,6 +196,9 @@
 
           dynamodb-endpoint
           (.withDynamoDBEndpoint dynamodb-endpoint)
+          
+          billing-mode
+          (.withBillingMode billing-mode)
 
           initial-position-in-stream
           (.withInitialPositionInStream


### PR DESCRIPTION
This allows creating on-demand capacity tables, which is particularly useful for development when you don't want to create many unused tables with provisioned capacity.

See https://github.com/awslabs/amazon-kinesis-client/blob/f38dd18ed1d41b9dd3839366d16a58b832292a0b/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java#L1301-L1309