### PR TITLE
Fix some tests / address reflection warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,13 @@ jobs:
           # NOTE: only one ns is exercised for now, since other test namespaces seem side-effectful.
           command: lein with-profile -user,-dev<< parameters.extra-profiles >>,+<< parameters.clojure-version >> do clean, test :only amazonica.test.core
 
+      - run:
+          name: Create pseudo-credentials for the next step
+          command: mkdir -p ~/.aws; echo -e "[foo]\naws_access_key_id = aaki\naws_secret_access_key = asak" > ~/.aws/credentials 
+      - run:
+          name: Run Eastwood
+          command: lein with-profile -user,+test<< parameters.extra-profiles >>,+<< parameters.clojure-version >> eastwood
+
 workflows:
   default:
     jobs:
@@ -59,4 +66,4 @@ workflows:
             parameters:
               executor: [openjdk8, openjdk11]
               extra-profiles: ["", ",+aws-sources"]
-              clojure-version: ["1.8", "1.9", "1.10.1", "1.10.2"]
+              clojure-version: ["1.8", "1.9", "1.10.1", "1.10.2", "1.10.3"]

--- a/project.clj
+++ b/project.clj
@@ -21,10 +21,15 @@
                  [robert/hooke "1.3.0"]
                  [com.taoensso/nippy "3.1.1"]]
   :jvm-opts     ["-Damazonica.internal.test.using-sources=false"]
-  :profiles {:1.8         {:dependencies [[org.clojure/clojure "1.8.0"]]}
+  :eastwood {:exclude-linters [:def-in-def :deprecations :unlimited-use :unused-ret-vals :local-shadows-var]
+             :ignored-faults {:wrong-arity {amazonica.test.s3 true
+                                            amazonica.test.kinesis-firehose true}}}
+  :profiles {:dev {:plugins [[jonase/eastwood "0.5.2"]]}
+             :1.8         {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9         {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10.1      {:dependencies [[org.clojure/clojure "1.10.1"]]}
              :1.10.2      {:dependencies [[org.clojure/clojure "1.10.2"]]}
+             :1.10.3      {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :aws-sources {:jvm-opts     ["-Damazonica.internal.test.using-sources=true"]
                            :dependencies [[com.amazonaws/amazon-kinesis-client "1.9.3" :classifier "sources"]
                                           [com.amazonaws/aws-java-sdk-accessanalyzer "1.11.850" :classifier "sources"]

--- a/src/amazonica/aws/cloudfront.clj
+++ b/src/amazonica/aws/cloudfront.clj
@@ -1,5 +1,5 @@
 (ns amazonica.aws.cloudfront
-  (:require [amazonica.core :only set-client])
+  (:require [amazonica.core])
   (:import com.amazonaws.services.cloudfront.AmazonCloudFrontClient))
 
 (amazonica.core/set-client AmazonCloudFrontClient *ns*)

--- a/test/amazonica/test/apigateway.clj
+++ b/test/amazonica/test/apigateway.clj
@@ -11,12 +11,12 @@
         creds  (-> "user.home"
                    System/getProperty
                    (str file)
-                   slurp
+                   ^String (slurp)
                    (.split "\n"))]
     (clojure.set/rename-keys
       (reduce
         (fn [m e]
-          (let [pair (.split e "=")]
+          (let [pair (.split ^String e "=")]
             (if (some #{access secret} [(first pair)])
                 (apply assoc m pair)
                 m)))
@@ -24,7 +24,7 @@
         creds)
       {access :access-key secret :secret-key})))
 
-(deftest apigateway []
+(deftest apigateway
 
   (get-rest-apis cred)
 

--- a/test/amazonica/test/cloudwatch.clj
+++ b/test/amazonica/test/cloudwatch.clj
@@ -7,7 +7,7 @@
         [amazonica.core]
         [amazonica.aws.cloudwatch]))
 
-(deftest cloudwatch []
+(deftest cloudwatch
 
   (clojure.pprint/pprint
     (list-metrics      

--- a/test/amazonica/test/core.clj
+++ b/test/amazonica/test/core.clj
@@ -123,31 +123,31 @@
        (remove #{:amazonica/source :amazonica/method-name})))
 
 (deftest camel->keyword-changes-tests
-  "See https://github.com/mcohen01/amazonica/issues/256"
-  (doseq [[service changed-fn-names] changed-camel->keyword-vars
-          [old-name new-name] changed-fn-names
-          :let [service-ns-sym (symbol (str "amazonica.aws." service))
-                old (ns-resolve service-ns-sym old-name)
-                new (ns-resolve service-ns-sym new-name)]]
-    (is (not= old-name new-name))
-    (is (some? old) (str "missing old var: " service " " old-name))
-    (is (some? new) (str "missing new var: " service " " new-name))
+  (testing "See https://github.com/mcohen01/amazonica/issues/256"
+    (doseq [[service changed-fn-names] changed-camel->keyword-vars
+            [old-name new-name] changed-fn-names
+            :let [service-ns-sym (symbol (str "amazonica.aws." service))
+                  old (ns-resolve service-ns-sym old-name)
+                  new (ns-resolve service-ns-sym new-name)]]
+      (is (not= old-name new-name))
+      (is (some? old) (str "missing old var: " service " " old-name))
+      (is (some? new) (str "missing new var: " service " " new-name))
 
-    (is (= #{:arglists
-             :ns
-             :name
-             :amazonica/client
-             :amazonica/methods
-             :amazonica/deprecated-in-favor-of}
-           (set (relevant-keys (meta old)))))
-    (is (= #{:arglists
-             :ns
-             :name
-             :amazonica/client
-             :amazonica/methods}
-           (set (relevant-keys (meta new)))))
-    (is (= new
-           (get (meta old) :amazonica/deprecated-in-favor-of))))
+      (is (= #{:arglists
+               :ns
+               :name
+               :amazonica/client
+               :amazonica/methods
+               :amazonica/deprecated-in-favor-of}
+             (set (relevant-keys (meta old)))))
+      (is (= #{:arglists
+               :ns
+               :name
+               :amazonica/client
+               :amazonica/methods}
+             (set (relevant-keys (meta new)))))
+      (is (= new
+             (get (meta old) :amazonica/deprecated-in-favor-of)))))
 
   ;; Make sure we don't accidentally attach new metadata keys to old, untouched
   ;; vars:
@@ -239,9 +239,9 @@
                              (do
                                (doseq [item arglist-map-or-vec]
                                  (is (symbol? item)
-                                     arglist-map-or-vec))
+                                     (pr-str arglist-map-or-vec)))
                                true)))
-                    arglist)
+                    (pr-str arglist))
                 (do
                   (is (vector? arglist))
                   (doseq [item arglist]

--- a/test/amazonica/test/datapipeline.clj
+++ b/test/amazonica/test/datapipeline.clj
@@ -4,7 +4,7 @@
         [amazonica.core]
         [amazonica.aws.datapipeline]))
 
-(deftest datapipeline []
+(deftest datapipeline
   
   (let [pid (:pipeline-id
               (create-pipeline

--- a/test/amazonica/test/dynamodbv2.clj
+++ b/test/amazonica/test/dynamodbv2.clj
@@ -97,8 +97,8 @@
                             {:id {:s "foo"}
                              :date {:n 123456}}))]
       (is (= (dissoc item :bytes) (dissoc ret-item :bytes)))
-      (is (= (-> item :bytes String.)
-             (-> ret-item :bytes .array String.)))))
+      (is (= (-> item ^bytes (:bytes) String.)
+             (-> ret-item ^java.nio.ByteBuffer (:bytes) .array String.)))))
   
     
   (query :table-name table

--- a/test/amazonica/test/ec2.clj
+++ b/test/amazonica/test/ec2.clj
@@ -1,10 +1,11 @@
 (ns amazonica.test.ec2
-  (:import com.amazonaws.services.ec2.model.RunInstancesRequest)
+  (:import com.amazonaws.services.ec2.model.RunInstancesRequest
+           com.amazonaws.services.ec2.model.BlockDeviceMapping)
   (:use [clojure.test]
         [clojure.pprint]
         [amazonica.aws.ec2]))
 
-(deftest ec2 []
+(deftest ec2
   
   (def vpc-id
    (-> (create-vpc :cidr-block "10.0.0.0/16") :vpc :vpc-id))
@@ -62,6 +63,6 @@
   (let [pojo (RunInstancesRequest.)]
     (amazonica.core/set-fields pojo {:block-device-mappings [{:device-name "foobar"}]})
     (is (= "foobar"
-           (-> pojo .getBlockDeviceMappings first .getDeviceName))))
+           (-> pojo .getBlockDeviceMappings ^BlockDeviceMapping (first) .getDeviceName))))
   
 )

--- a/test/amazonica/test/glacier.clj
+++ b/test/amazonica/test/glacier.clj
@@ -3,7 +3,7 @@
         [clojure.pprint]
         [amazonica.aws.glacier]))
 
-(deftest glacier []
+(deftest glacier
 
   (def upload-file (java.io.File. "upload.txt"))
   

--- a/test/amazonica/test/kinesis_firehose.clj
+++ b/test/amazonica/test/kinesis_firehose.clj
@@ -17,7 +17,7 @@
 (defn list-delivery-streams-matching-prefix []
   (->> (fh/list-delivery-streams cred)
        :delivery-stream-names
-       (filter #(.startsWith % stream-prefix))))
+       (filter #(.startsWith ^String % stream-prefix))))
 
 (defn delete-delivery-streams-matching-prefix []
   (->> (list-delivery-streams-matching-prefix)

--- a/test/amazonica/test/kms.clj
+++ b/test/amazonica/test/kms.clj
@@ -3,7 +3,7 @@
         [amazonica.core]
         [amazonica.aws.kms]))
 
-(deftest kms []
+(deftest kms
   (list-keys)
 
   (let [k (create-key)

--- a/test/amazonica/test/lambda.clj
+++ b/test/amazonica/test/lambda.clj
@@ -15,12 +15,12 @@
     {:access-key (get creds "aws_access_key_id")
      :secret-key (get creds "aws_secret_access_key")}))
 
-(def role (delay (-> #(.contains (:role-name %) "lambda")
+(def role (delay (-> #(.contains ^String (:role-name %) "lambda")
                      (filter (:roles (iam/list-roles)))
                      first
                      :arn)))
 
-(deftest aws-lambda []
+(deftest aws-lambda
 
   (def handler "exports.helloWorld = function(event, context) {
                   console.log('value1 = ' + event.key1)

--- a/test/amazonica/test/redshift.clj
+++ b/test/amazonica/test/redshift.clj
@@ -3,7 +3,7 @@
         [amazonica.core]
         [amazonica.aws.redshift]))
 
-(deftest redshift []
+(deftest redshift
 
   (println (describe-cluster-versions))
   (println (describe-clusters))
@@ -16,7 +16,7 @@
     (throw (Exception. "create-cluster-subnet-group did not throw exception"))
     (catch Exception e
       (is (.contains 
-            (:message (ex->map e))
+            ^String (:message (ex->map e))
             "Some input subnets in :[1, 2, 3, 4] are invalid."))))
     
  (amazonica.aws.redshift/describe-events :source-type "cluster")
@@ -42,7 +42,7 @@
     (catch Exception e
       (println (:message (ex->map e)))
       (is (.contains
-            (:message (ex->map e))
+            ^String (:message (ex->map e))
             "Could not find parameter with name: my_new_param"))))
   
   (delete-cluster-parameter-group :parameter-group-name "foobar")

--- a/test/amazonica/test/route53.clj
+++ b/test/amazonica/test/route53.clj
@@ -2,7 +2,7 @@
   (:use [clojure.test]
         [amazonica.aws.route53]))
 
-(deftest route53 []
+(deftest route53
 
   (let [config {:caller-reference (str (java.util.UUID/randomUUID))
                 :health-check-config

--- a/test/amazonica/test/s3.clj
+++ b/test/amazonica/test/s3.clj
@@ -25,11 +25,11 @@
         creds  (-> "user.home"
                    System/getProperty
                    (str file)
-                   slurp
+                   ^String (slurp)
                    (.split "\n"))]
     (clojure.set/rename-keys
       (reduce
-        (fn [m e]
+        (fn [m ^String e]
           (let [pair (.split e "=")]
             (if (some #{access secret} [(first pair)])
                 (apply assoc m pair)
@@ -40,11 +40,11 @@
 
 (deftest s3
 
-  (def bucket1 (.. (UUID/randomUUID) toString))
-  (def bucket2 (.. (UUID/randomUUID) toString))
-  (def date    (.plusDays (DateTime.) 2))
-  (def upload-file   (java.io.File. "upload.txt"))
-  (def download-file (java.io.File. "download.txt"))
+  (def ^String bucket1 (.. (UUID/randomUUID) toString))
+  (def ^String bucket2 (.. (UUID/randomUUID) toString))
+  (def ^DateTime date    (.plusDays (DateTime.) 2))
+  (def ^java.io.File upload-file   (java.io.File. "upload.txt"))
+  (def ^java.io.File download-file (java.io.File. "download.txt"))
 
   (spit upload-file "hello world")
 
@@ -264,14 +264,14 @@
         (f "x-amz-grant-read")
         (filter (:grants obj))
         first
-        (get-in [:grantee :identifier])
+        ^String (get-in [:grantee :identifier])
         (.contains "AllUsers")))
     (is
       (->
         (f "x-amz-grant-write")
         (filter (:grants obj))
         first
-        (get-in [:grantee :identifier])
+        ^String (get-in [:grantee :identifier])
         (.contains "AuthenticatedUsers"))))
 
   (put-object cred
@@ -360,12 +360,12 @@
                 :bucket-name bucket1
                 :key "jenny"
                 :file upload-file)]
-    (is 32 (.length (:etag etag))))
+    (is (= 32 (.length ^String (:etag etag)))))
 
 
-  (is "text/plain"
-    (get-in (get-object cred bucket1 "jenny")
-            [:object-metadata :raw-metadata :Content-Type]))
+  (is (= "text/plain"
+         (get-in (get-object cred bucket1 "jenny")
+                 [:object-metadata :raw-metadata :Content-Type])))
 
   (get-object
     cred

--- a/test/amazonica/test/s3transfer.clj
+++ b/test/amazonica/test/s3transfer.clj
@@ -12,11 +12,11 @@
         creds  (-> "user.home"
                    System/getProperty
                    (str file)
-                   slurp
+                   ^String slurp
                    (.split "\n"))]
     (clojure.set/rename-keys 
       (reduce
-        (fn [m e]
+        (fn [m ^String e]
           (let [pair (.split e "=")]
             (if (some #{access secret} [(first pair)])
                 (apply assoc m pair)
@@ -26,11 +26,11 @@
       {access :access-key secret :secret-key})))
 
 
-(deftest s3transfer []
+(deftest s3transfer
 
-  (def file "upload.txt")
-  (def down-dir (java.io.File. (str "/tmp/" file)))
-  (def bucket "0a178f17-5593-480f-bcf0-cb10f7654b19")
+  (def ^String file "upload.txt")
+  (def ^java.io.File down-dir (java.io.File. (str "/tmp/" file)))
+  (def ^String bucket "0a178f17-5593-480f-bcf0-cb10f7654b19")
   
   (s3/create-bucket bucket)
   

--- a/test/amazonica/test/securitytoken.clj
+++ b/test/amazonica/test/securitytoken.clj
@@ -4,7 +4,7 @@
         [amazonica.aws.s3 :exclude [show-functions client-class get-cached-response-metadata set-region]]
         [amazonica.aws.securitytoken :exclude [show-functions waiters client-class]]))
 
-(deftest securitytoken []
+(deftest securitytoken
 
   (let [session (:credentials (get-session-token))]
     (is (= true (contains? session :access-key)))

--- a/test/amazonica/test/simplesystemsmanagement.clj
+++ b/test/amazonica/test/simplesystemsmanagement.clj
@@ -5,7 +5,7 @@
   (:import
    (com.amazonaws.services.simplesystemsmanagement.model SendCommandRequest)))
 
-(deftest simplesystemsmanagement []
+(deftest simplesystemsmanagement
 
   ;; test for marshalling map values
   ;; see https://github.com/mcohen01/amazonica/issues/219

--- a/test/amazonica/test/sns.clj
+++ b/test/amazonica/test/sns.clj
@@ -4,7 +4,7 @@
         [clojure.pprint]
         [amazonica.aws.sns]))
 
-(deftest sns []
+(deftest sns
 
   (def topic-name (.. (UUID/randomUUID) toString))
   

--- a/test/amazonica/test/sqs.clj
+++ b/test/amazonica/test/sqs.clj
@@ -4,7 +4,7 @@
   (:import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
            com.amazonaws.services.sqs.model.QueueDoesNotExistException))
 
-(deftest sqs []
+(deftest sqs
 
   (list-queues)
   


### PR DESCRIPTION
* Fix some tests (missing `=` from `is`)
* Address reflection warnings
* Setup Eastwood in CI, as it helped find these (as it helped develop https://github.com/mcohen01/amazonica/pull/445)
  * Some of its linters are disabled, simply for avoiding a disproportionate effort fixing things. They could be eventually re-enabled.

Hope you find these useful!

-V