### PR TITLE
Use v2 model interfaces in v1 kinesis client library to support graceful shutdown

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -258,6 +258,6 @@
                                           [com.amazonaws/aws-java-sdk-workspaces "1.11.850" :classifier "sources"]
                                           [com.amazonaws/aws-java-sdk-xray "1.11.850" :classifier "sources"]
                                           ;; the :exclusions prevent warnings due to version ranges:
-                                          [com.amazonaws/dynamodb-streams-kinesis-adapter "1.2.1" :classifier "sources" :exclusions [*]]
+                                          [com.amazonaws/dynamodb-streams-kinesis-adapter "1.5.3" :classifier "sources" :exclusions [*]]
                                           [com.amazonaws/jmespath-java "1.11.850" :classifier "sources"]
                                           [software.amazon.ion/ion-java "1.0.2" :classifier "sources"]]}})

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :dependencies [[org.clojure/clojure "1.8.0" :scope "provided"]
                  [org.clojure/algo.generic "0.1.2"]
                  [com.amazonaws/aws-java-sdk "1.11.968" :exclusions [joda-time]]
-                 [com.amazonaws/amazon-kinesis-client "1.14.2" :exclusions [joda-time]]
+                 [com.amazonaws/amazon-kinesis-client "1.14.7" :exclusions [joda-time]]
                  [com.amazonaws/dynamodb-streams-kinesis-adapter "1.5.2"
                   :exclusions [com.amazonaws/amazon-kinesis-client
                                com.amazonaws/aws-java-sdk-cloudwatch
@@ -31,7 +31,7 @@
              :1.10.2      {:dependencies [[org.clojure/clojure "1.10.2"]]}
              :1.10.3      {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :aws-sources {:jvm-opts     ["-Damazonica.internal.test.using-sources=true"]
-                           :dependencies [[com.amazonaws/amazon-kinesis-client "1.9.3" :classifier "sources"]
+                           :dependencies [[com.amazonaws/amazon-kinesis-client "1.14.7" :classifier "sources"]
                                           [com.amazonaws/aws-java-sdk-accessanalyzer "1.11.850" :classifier "sources"]
                                           [com.amazonaws/aws-java-sdk-acm "1.11.850" :classifier "sources"]
                                           [com.amazonaws/aws-java-sdk-acmpca "1.11.850" :classifier "sources"]


### PR DESCRIPTION
Fixes https://github.com/mcohen01/amazonica/issues/453

See "Updated Interface (Version 2)" in https://docs.aws.amazon.com/streams/latest/dev/kinesis-record-processor-implementation-app-java.html#kinesis-record-processor-implementation-factory-java for details.

This allows users to call `startGracefulShutdown` on the `Worker` instance to shutdown gracefully.
