### PR TITLE
fix AmazonDynamoDBStreamsAdapterClient init

### DIFF
--- a/src/amazonica/aws/kinesis.clj
+++ b/src/amazonica/aws/kinesis.clj
@@ -304,9 +304,12 @@
            ;; this will result in some warnings at debug from the kinesis client lib as it will try to set the region/endpoint on this client. 
            ;; These are safe to ignore as we pre-configure the correct values
            (.kinesisClient
-            (doto (AmazonDynamoDBStreamsAdapterClient. ^AWSCredentials provider (.getKinesisClientConfiguration config))
+            (doto (if provider
+                    (AmazonDynamoDBStreamsAdapterClient. ^AWSCredentialsProvider provider (.getKinesisClientConfiguration config))
+                    (AmazonDynamoDBStreamsAdapterClient. (.getKinesisClientConfiguration config)))
               (cond->
-               region-name ^AmazonDynamoDBStreamsAdapterClient (.setRegion (Region/getRegion (Regions/fromName region-name)))
+               region-name ^AmazonDynamoDBStreamsAdapterClient (.setRegion (Region/getRegion (Regions/fromName region-name))))
+              (cond->
                endpoint ^AmazonDynamoDBStreamsAdapterClient (.setEndpoint endpoint)))))
          (.build)) worker-identifier]))
 


### PR DESCRIPTION
Fix for the change made in https://github.com/mcohen01/amazonica/pull/455

I didn't verify this flag initialised classes as expected as we don't use it in our code path and there's not a running test case.

I've now verified that it does at least initialise the clients and kinesis worker, but don't have the setup to test it in full.