### PR TITLE
`[lein check]` Reflection warnings in core and s3

### DIFF
--- a/src/amazonica/aws/s3.clj
+++ b/src/amazonica/aws/s3.clj
@@ -222,7 +222,7 @@
         (.setMethod req (coerce-value method HttpMethod)))
       (if-let [response-headers (:response-headers value)]
         (.setResponseHeaders req response-headers))
-      (if-let [sse-algorithm (:sse-algorithm value)]
+      (if-let [^String sse-algorithm (:sse-algorithm value)]
         (.setSSEAlgorithm req sse-algorithm))
       (if-let [sse-customer-key (:sse-customer-key value)]
         (.setSSECustomerKey

--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -20,7 +20,6 @@
              Regions]
            com.amazonaws.client.builder.AwsClientBuilder
            com.amazonaws.client.builder.AwsClientBuilder$EndpointConfiguration
-           com.amazonaws.services.s3.model.CryptoConfiguration
            org.joda.time.DateTime
            org.joda.time.base.AbstractInstant
            java.io.File
@@ -247,9 +246,8 @@
         key       (or (:secret-key encryption)
                       (:key-pair encryption)
                       (:kms-customer-master-key encryption))
-        ^CryptoConfiguration
         crypto    (invoke-constructor
-                   "com.amazonaws.services.s3.model.CryptoConfiguration" [])
+                    "com.amazonaws.services.s3.model.CryptoConfiguration" [])
         _         (when (:kms-customer-master-key encryption)
                     (.setAwsKmsRegion crypto (Region/getRegion (get-region {:endpoint (:region key)})) ))
         em        (when-not (:kms-customer-master-key encryption)


### PR DESCRIPTION
First, thanks for this lib, if it didn't exist we'd need to start by making something like it, and ours would be worse.

This PR merely adds some type hints to avoid Reflection Warnings when compiling.

Before:
```
$ lein check
Compiling namespace amazonica.aws.accessanalyzer
Reflection warning, amazonica/core.clj:253:21 - call to method setAwsKmsRegion can't be resolved (target class is unknown).
Reflection warning, amazonica/core.clj:264:21 - call to method withCryptoProvider can't be resolved (target class is unknown).
Reflection warning, amazonica/core.clj:991:14 - reference to field getParameters can't be resolved.
Reflection warning, amazonica/core.clj:991:14 - reference to field getType can't be resolved.
Reflection warning, amazonica/core.clj:997:25 - reference to field newInstance can't be resolved.
Reflection warning, amazonica/core.clj:1058:50 - reference to field getName can't be resolved.
Compiling namespace amazonica.aws.acm
Compiling namespace amazonica.aws.acmpca
Compiling namespace amazonica.aws.amplify
Compiling namespace amazonica.aws.apigateway
Compiling namespace amazonica.aws.apigatewaymanagementapi
Compiling namespace amazonica.aws.apigatewayv2
Compiling namespace amazonica.aws.appconfig
Compiling namespace amazonica.aws.applicationautoscaling
Compiling namespace amazonica.aws.applicationinsights
Compiling namespace amazonica.aws.appstream
Compiling namespace amazonica.aws.appsync
Compiling namespace amazonica.aws.athena
Compiling namespace amazonica.aws.augmentedairuntime
Compiling namespace amazonica.aws.autoscaling
Compiling namespace amazonica.aws.autoscalingplans
Compiling namespace amazonica.aws.backup
Compiling namespace amazonica.aws.batch
Compiling namespace amazonica.aws.budgets
Compiling namespace amazonica.aws.chime
Compiling namespace amazonica.aws.cloud9
Compiling namespace amazonica.aws.clouddirectory
Compiling namespace amazonica.aws.cloudformation
Compiling namespace amazonica.aws.cloudfront
Compiling namespace amazonica.aws.cloudhsmv2
Compiling namespace amazonica.aws.cloudsearchdomain
Compiling namespace amazonica.aws.cloudsearchv2
Compiling namespace amazonica.aws.cloudtrail
Compiling namespace amazonica.aws.cloudwatch
Compiling namespace amazonica.aws.cloudwatchevents
Compiling namespace amazonica.aws.codebuild
Compiling namespace amazonica.aws.codecommit
Compiling namespace amazonica.aws.codedeploy
Compiling namespace amazonica.aws.codepipeline
Compiling namespace amazonica.aws.codestar
Compiling namespace amazonica.aws.cognitoidentity
Compiling namespace amazonica.aws.cognitoidp
Compiling namespace amazonica.aws.cognitosync
Compiling namespace amazonica.aws.comprehend
Compiling namespace amazonica.aws.comprehendmedical
Compiling namespace amazonica.aws.computeoptimizer
Compiling namespace amazonica.aws.config
Compiling namespace amazonica.aws.connect
Compiling namespace amazonica.aws.connectparticipant
Compiling namespace amazonica.aws.costandusagereport
Compiling namespace amazonica.aws.costexplorer
Compiling namespace amazonica.aws.databasemigrationservice
Compiling namespace amazonica.aws.dataexchange
Compiling namespace amazonica.aws.datapipeline
Compiling namespace amazonica.aws.datasync
Compiling namespace amazonica.aws.dax
Compiling namespace amazonica.aws.detective
Compiling namespace amazonica.aws.devicefarm
Compiling namespace amazonica.aws.directconnect
Compiling namespace amazonica.aws.directory
Compiling namespace amazonica.aws.dlm
Compiling namespace amazonica.aws.docdb
Compiling namespace amazonica.aws.dynamodbv2
Compiling namespace amazonica.aws.ec2
Compiling namespace amazonica.aws.ec2instanceconnect
Compiling namespace amazonica.aws.ecr
Compiling namespace amazonica.aws.ecs
Compiling namespace amazonica.aws.eks
Compiling namespace amazonica.aws.elasticache
Compiling namespace amazonica.aws.elasticbeanstalk
Compiling namespace amazonica.aws.elasticfilesystem
Compiling namespace amazonica.aws.elasticloadbalancing
Compiling namespace amazonica.aws.elasticloadbalancingv2
Compiling namespace amazonica.aws.elasticmapreduce
Compiling namespace amazonica.aws.elasticsearch
Compiling namespace amazonica.aws.elastictranscoder
Compiling namespace amazonica.aws.eventbridge
Compiling namespace amazonica.aws.fms
Compiling namespace amazonica.aws.forecast
Compiling namespace amazonica.aws.forecastquery
Compiling namespace amazonica.aws.frauddetector
Compiling namespace amazonica.aws.fsx
Compiling namespace amazonica.aws.gamelift
Compiling namespace amazonica.aws.glacier
Compiling namespace amazonica.aws.globalaccelerator
Compiling namespace amazonica.aws.glue
Compiling namespace amazonica.aws.greengrass
Compiling namespace amazonica.aws.groundstation
Compiling namespace amazonica.aws.guardduty
Compiling namespace amazonica.aws.health
Compiling namespace amazonica.aws.identitymanagement
Compiling namespace amazonica.aws.imagebuilder
Compiling namespace amazonica.aws.importexport
Compiling namespace amazonica.aws.inspector
Compiling namespace amazonica.aws.iot
Compiling namespace amazonica.aws.iotanalytics
Compiling namespace amazonica.aws.iotdata
Compiling namespace amazonica.aws.kafka
Compiling namespace amazonica.aws.kendra
Compiling namespace amazonica.aws.kinesis
Compiling namespace amazonica.aws.kinesisanalytics
Compiling namespace amazonica.aws.kinesisfirehose
Compiling namespace amazonica.aws.kms
Compiling namespace amazonica.aws.lakeformation
Compiling namespace amazonica.aws.lambda
Compiling namespace amazonica.aws.lexmodelbuilding
Compiling namespace amazonica.aws.lexruntime
Compiling namespace amazonica.aws.lightsail
Compiling namespace amazonica.aws.logs
Compiling namespace amazonica.aws.machinelearning
Compiling namespace amazonica.aws.macie
Compiling namespace amazonica.aws.managedblockchain
Compiling namespace amazonica.aws.mediaconvert
Compiling namespace amazonica.aws.medialive
Compiling namespace amazonica.aws.mediapackage
Compiling namespace amazonica.aws.mediastore
Compiling namespace amazonica.aws.migrationhub
Compiling namespace amazonica.aws.mobile
Compiling namespace amazonica.aws.mq
Compiling namespace amazonica.aws.mturk
Compiling namespace amazonica.aws.neptune
Compiling namespace amazonica.aws.opsworks
Compiling namespace amazonica.aws.organizations
Compiling namespace amazonica.aws.personalize
Compiling namespace amazonica.aws.personalizeruntime
Compiling namespace amazonica.aws.pi
Compiling namespace amazonica.aws.pinpoint
Compiling namespace amazonica.aws.polly
Compiling namespace amazonica.aws.pricing
Compiling namespace amazonica.aws.qldb
Compiling namespace amazonica.aws.quicksight
Compiling namespace amazonica.aws.rds
Compiling namespace amazonica.aws.rdsdata
Compiling namespace amazonica.aws.redshift
Compiling namespace amazonica.aws.rekognition
Compiling namespace amazonica.aws.resourcegroups
Compiling namespace amazonica.aws.resourcegroupstaggingapi
Compiling namespace amazonica.aws.route53
Compiling namespace amazonica.aws.route53domains
Compiling namespace amazonica.aws.s3
Reflection warning, amazonica/aws/s3.clj:226:9 - call to method setSSEAlgorithm on com.amazonaws.services.s3.model.GeneratePresignedUrlRequest can't be resolved (argument types: unknown).
Reflection warning, amazonica/aws/s3.clj:245:5 - call to com.amazonaws.services.s3.model.SSECustomerKey ctor can't be resolved.
Compiling namespace amazonica.aws.s3transfer
Compiling namespace amazonica.aws.sagemaker
Compiling namespace amazonica.aws.sagemaker-runtime
Compiling namespace amazonica.aws.secretsmanager
Compiling namespace amazonica.aws.securityhub
Compiling namespace amazonica.aws.securitytoken
Compiling namespace amazonica.aws.servermigration
Compiling namespace amazonica.aws.servicecatalog
Compiling namespace amazonica.aws.servicediscovery
Compiling namespace amazonica.aws.shield
Compiling namespace amazonica.aws.simpledb
Compiling namespace amazonica.aws.simpleemail
Compiling namespace amazonica.aws.simplesystemsmanagement
Compiling namespace amazonica.aws.simpleworkflow
Compiling namespace amazonica.aws.snowball
Compiling namespace amazonica.aws.sns
Compiling namespace amazonica.aws.sqs
Compiling namespace amazonica.aws.stepfunctions
Compiling namespace amazonica.aws.storagegateway
Compiling namespace amazonica.aws.support
Compiling namespace amazonica.aws.textract
Compiling namespace amazonica.aws.timestreamquery
Compiling namespace amazonica.aws.timestreamwrite
Compiling namespace amazonica.aws.transcribe
Compiling namespace amazonica.aws.transfer
Compiling namespace amazonica.aws.translate
Compiling namespace amazonica.aws.waf
Compiling namespace amazonica.aws.workspaces
Compiling namespace amazonica.aws.xray
Compiling namespace amazonica.core
Reflection warning, amazonica/core.clj:253:21 - call to method setAwsKmsRegion can't be resolved (target class is unknown).
Reflection warning, amazonica/core.clj:264:21 - call to method withCryptoProvider can't be resolved (target class is unknown).
Reflection warning, amazonica/core.clj:991:14 - reference to field getParameters can't be resolved.
Reflection warning, amazonica/core.clj:991:14 - reference to field getType can't be resolved.
Reflection warning, amazonica/core.clj:997:25 - reference to field newInstance can't be resolved.
Reflection warning, amazonica/core.clj:1058:50 - reference to field getName can't be resolved.
```

After:
```
$ lein check
Compiling namespace amazonica.aws.accessanalyzer
Compiling namespace amazonica.aws.acm
Compiling namespace amazonica.aws.acmpca
Compiling namespace amazonica.aws.amplify
Compiling namespace amazonica.aws.apigateway
Compiling namespace amazonica.aws.apigatewaymanagementapi
Compiling namespace amazonica.aws.apigatewayv2
Compiling namespace amazonica.aws.appconfig
Compiling namespace amazonica.aws.applicationautoscaling
Compiling namespace amazonica.aws.applicationinsights
Compiling namespace amazonica.aws.appstream
Compiling namespace amazonica.aws.appsync
Compiling namespace amazonica.aws.athena
Compiling namespace amazonica.aws.augmentedairuntime
Compiling namespace amazonica.aws.autoscaling
Compiling namespace amazonica.aws.autoscalingplans
Compiling namespace amazonica.aws.backup
Compiling namespace amazonica.aws.batch
Compiling namespace amazonica.aws.budgets
Compiling namespace amazonica.aws.chime
Compiling namespace amazonica.aws.cloud9
Compiling namespace amazonica.aws.clouddirectory
Compiling namespace amazonica.aws.cloudformation
Compiling namespace amazonica.aws.cloudfront
Compiling namespace amazonica.aws.cloudhsmv2
Compiling namespace amazonica.aws.cloudsearchdomain
Compiling namespace amazonica.aws.cloudsearchv2
Compiling namespace amazonica.aws.cloudtrail
Compiling namespace amazonica.aws.cloudwatch
Compiling namespace amazonica.aws.cloudwatchevents
Compiling namespace amazonica.aws.codebuild
Compiling namespace amazonica.aws.codecommit
Compiling namespace amazonica.aws.codedeploy
Compiling namespace amazonica.aws.codepipeline
Compiling namespace amazonica.aws.codestar
Compiling namespace amazonica.aws.cognitoidentity
Compiling namespace amazonica.aws.cognitoidp
Compiling namespace amazonica.aws.cognitosync
Compiling namespace amazonica.aws.comprehend
Compiling namespace amazonica.aws.comprehendmedical
Compiling namespace amazonica.aws.computeoptimizer
Compiling namespace amazonica.aws.config
Compiling namespace amazonica.aws.connect
Compiling namespace amazonica.aws.connectparticipant
Compiling namespace amazonica.aws.costandusagereport
Compiling namespace amazonica.aws.costexplorer
Compiling namespace amazonica.aws.databasemigrationservice
Compiling namespace amazonica.aws.dataexchange
Compiling namespace amazonica.aws.datapipeline
Compiling namespace amazonica.aws.datasync
Compiling namespace amazonica.aws.dax
Compiling namespace amazonica.aws.detective
Compiling namespace amazonica.aws.devicefarm
Compiling namespace amazonica.aws.directconnect
Compiling namespace amazonica.aws.directory
Compiling namespace amazonica.aws.dlm
Compiling namespace amazonica.aws.docdb
Compiling namespace amazonica.aws.dynamodbv2
Compiling namespace amazonica.aws.ec2
Compiling namespace amazonica.aws.ec2instanceconnect
Compiling namespace amazonica.aws.ecr
Compiling namespace amazonica.aws.ecs
Compiling namespace amazonica.aws.eks
Compiling namespace amazonica.aws.elasticache
Compiling namespace amazonica.aws.elasticbeanstalk
Compiling namespace amazonica.aws.elasticfilesystem
Compiling namespace amazonica.aws.elasticloadbalancing
Compiling namespace amazonica.aws.elasticloadbalancingv2
Compiling namespace amazonica.aws.elasticmapreduce
Compiling namespace amazonica.aws.elasticsearch
Compiling namespace amazonica.aws.elastictranscoder
Compiling namespace amazonica.aws.eventbridge
Compiling namespace amazonica.aws.fms
Compiling namespace amazonica.aws.forecast
Compiling namespace amazonica.aws.forecastquery
Compiling namespace amazonica.aws.frauddetector
Compiling namespace amazonica.aws.fsx
Compiling namespace amazonica.aws.gamelift
Compiling namespace amazonica.aws.glacier
Compiling namespace amazonica.aws.globalaccelerator
Compiling namespace amazonica.aws.glue
Compiling namespace amazonica.aws.greengrass
Compiling namespace amazonica.aws.groundstation
Compiling namespace amazonica.aws.guardduty
Compiling namespace amazonica.aws.health
Compiling namespace amazonica.aws.identitymanagement
Compiling namespace amazonica.aws.imagebuilder
Compiling namespace amazonica.aws.importexport
Compiling namespace amazonica.aws.inspector
Compiling namespace amazonica.aws.iot
Compiling namespace amazonica.aws.iotanalytics
Compiling namespace amazonica.aws.iotdata
Compiling namespace amazonica.aws.kafka
Compiling namespace amazonica.aws.kendra
Compiling namespace amazonica.aws.kinesis
Compiling namespace amazonica.aws.kinesisanalytics
Compiling namespace amazonica.aws.kinesisfirehose
Compiling namespace amazonica.aws.kms
Compiling namespace amazonica.aws.lakeformation
Compiling namespace amazonica.aws.lambda
Compiling namespace amazonica.aws.lexmodelbuilding
Compiling namespace amazonica.aws.lexruntime
Compiling namespace amazonica.aws.lightsail
Compiling namespace amazonica.aws.logs
Compiling namespace amazonica.aws.machinelearning
Compiling namespace amazonica.aws.macie
Compiling namespace amazonica.aws.managedblockchain
Compiling namespace amazonica.aws.mediaconvert
Compiling namespace amazonica.aws.medialive
Compiling namespace amazonica.aws.mediapackage
Compiling namespace amazonica.aws.mediastore
Compiling namespace amazonica.aws.migrationhub
Compiling namespace amazonica.aws.mobile
Compiling namespace amazonica.aws.mq
Compiling namespace amazonica.aws.mturk
Compiling namespace amazonica.aws.neptune
Compiling namespace amazonica.aws.opsworks
Compiling namespace amazonica.aws.organizations
Compiling namespace amazonica.aws.personalize
Compiling namespace amazonica.aws.personalizeruntime
Compiling namespace amazonica.aws.pi
Compiling namespace amazonica.aws.pinpoint
Compiling namespace amazonica.aws.polly
Compiling namespace amazonica.aws.pricing
Compiling namespace amazonica.aws.qldb
Compiling namespace amazonica.aws.quicksight
Compiling namespace amazonica.aws.rds
Compiling namespace amazonica.aws.rdsdata
Compiling namespace amazonica.aws.redshift
Compiling namespace amazonica.aws.rekognition
Compiling namespace amazonica.aws.resourcegroups
Compiling namespace amazonica.aws.resourcegroupstaggingapi
Compiling namespace amazonica.aws.route53
Compiling namespace amazonica.aws.route53domains
Compiling namespace amazonica.aws.s3
Reflection warning, amazonica/aws/s3.clj:245:5 - call to com.amazonaws.services.s3.model.SSECustomerKey ctor can't be resolved.
Compiling namespace amazonica.aws.s3transfer
Compiling namespace amazonica.aws.sagemaker
Compiling namespace amazonica.aws.sagemaker-runtime
Compiling namespace amazonica.aws.secretsmanager
Compiling namespace amazonica.aws.securityhub
Compiling namespace amazonica.aws.securitytoken
Compiling namespace amazonica.aws.servermigration
Compiling namespace amazonica.aws.servicecatalog
Compiling namespace amazonica.aws.servicediscovery
Compiling namespace amazonica.aws.shield
Compiling namespace amazonica.aws.simpledb
Compiling namespace amazonica.aws.simpleemail
Compiling namespace amazonica.aws.simplesystemsmanagement
Compiling namespace amazonica.aws.simpleworkflow
Compiling namespace amazonica.aws.snowball
Compiling namespace amazonica.aws.sns
Compiling namespace amazonica.aws.sqs
Compiling namespace amazonica.aws.stepfunctions
Compiling namespace amazonica.aws.storagegateway
Compiling namespace amazonica.aws.support
Compiling namespace amazonica.aws.textract
Compiling namespace amazonica.aws.timestreamquery
Compiling namespace amazonica.aws.timestreamwrite
Compiling namespace amazonica.aws.transcribe
Compiling namespace amazonica.aws.transfer
Compiling namespace amazonica.aws.translate
Compiling namespace amazonica.aws.waf
Compiling namespace amazonica.aws.workspaces
Compiling namespace amazonica.aws.xray
Compiling namespace amazonica.core
```

The very last warning in `s3.clj` I'm not sure how to best resolve. It's an overloaded constructor that can take three different types as its single parameter.

Anyway, hope this helps. Thanks again!