### PR TITLE
Add minimal support for Kinesis Video Signaling Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ and the following dependency:
 * [Kinesis](#kinesis)
 * [Kinesis Analytics](#kinesisanalytics)
 * [KinesisFirehose](#kinesisfirehose)
+* Kinesis Video Streams with WebRTC (Signaling Channels)
 * [KMS](#kms)
 * Lake Formation
 * [Lambda](#lambda)

--- a/src/amazonica/aws/kinesisvideo.clj
+++ b/src/amazonica/aws/kinesisvideo.clj
@@ -1,0 +1,5 @@
+(ns amazonica.aws.kinesisvideo
+  (:require [amazonica.core :as amz])
+  (:import com.amazonaws.services.kinesisvideo.AmazonKinesisVideoClient))
+
+(amz/set-client AmazonKinesisVideoClient *ns*)

--- a/src/amazonica/aws/kinesisvideosignalingchannels.clj
+++ b/src/amazonica/aws/kinesisvideosignalingchannels.clj
@@ -1,0 +1,5 @@
+(ns amazonica.aws.kinesisvideosignalingchannels
+  (:require [amazonica.core :as amz])
+  (:import com.amazonaws.services.kinesisvideosignalingchannels.AmazonKinesisVideoSignalingChannelsClient))
+
+(amz/set-client AmazonKinesisVideoSignalingChannelsClient *ns*)


### PR DESCRIPTION
Using signaling channels requires calling API endpoints from both Kinesis Video and Kinesis Video Signaling Channels.

Kenesis Video also includes Video Streams which may require additional handling, but none of that is included here as I haven't tried to use that API directly.