### PR TITLE
Use DefaultAwsRegionProviderChain when looking up AWS region

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -18,7 +18,8 @@
            com.amazonaws.auth.profile.ProfileCredentialsProvider
            [com.amazonaws.regions
              Region
-             Regions]
+             Regions
+             DefaultAwsRegionProviderChain]
            com.amazonaws.client.builder.AwsClientBuilder
            com.amazonaws.client.builder.AwsClientBuilder$EndpointConfiguration
            org.joda.time.DateTime
@@ -145,6 +146,10 @@
   `(binding [*client-config* ~config]
      (do ~@body)))
 
+(defn- get-default-region []
+  (-> (DefaultAwsRegionProviderChain.)
+      (.getRegion)))
+
 (defn- builder ^AwsClientBuilder [^Class clazz]
   (let [^Method method (.getMethod clazz "builder" (make-array Class 0))]
     (.invoke method clazz (make-array Object 0))))
@@ -156,7 +161,7 @@
         _ (set-fields builder options)
         builder (if credentials (.withCredentials builder credentials) builder)
         builder (if configuration (.withClientConfiguration builder configuration) builder)
-        ^String endpoint (or (:endpoint raw-creds) (System/getenv "AWS_DEFAULT_REGION"))
+        ^String endpoint (or (:endpoint raw-creds) (get-default-region))
         builder (if endpoint
                   (if (.startsWith endpoint "http")
                       (.withEndpointConfiguration
@@ -228,7 +233,7 @@
 (defn- get-region ^Regions
   [credentials]
   (when-let [endpoint (or (:endpoint credentials)
-                          (System/getenv "AWS_DEFAULT_REGION"))]
+                          (get-default-region))]
     (if (contains? (fmap #(-> % str/upper-case (str/replace "_" ""))
                          (apply hash-set (seq (Regions/values))))
                    (-> (str/upper-case endpoint)


### PR DESCRIPTION
Use the built in [`DefaultAwsRegionProviderChain`](https://github.com/aws/aws-sdk-java/blob/1.12.323/aws-java-sdk-core/src/main/java/com/amazonaws/regions/DefaultAwsRegionProviderChain.java) to get the AWS region.

Note that this is technically a breaking change, as the [SDK uses `AWS_REGION`](https://github.com/aws/aws-sdk-java/blob/1.12.323/aws-java-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java#L289), not `AWS_DEFAULT_REGION` - it wouldn't be difficult to create a new provider chain which checks for both.

That said, this better matches the SDK documentation - which uses `AWS_REGION` https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html
