### PR TITLE
Set signing region when overriding endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![AWS logo](claws.png)
 # `Amazonica`
 
-A comprehensive Clojure client for the entire [Amazon AWS api][1].  
+A comprehensive Clojure client for the entire [Amazon AWS api][1].
 
 [![amazonica](https://circleci.com/gh/mcohen01/amazonica.svg?style=shield)](https://app.circleci.com/pipelines/github/mcohen01/amazonica)
 
@@ -372,7 +372,7 @@ The credentials map may contain zero or one of the following:
 - `:cred`, in which case the [`AWSCredentialsProvider`][23] instance provided will be used.
 - Or rather than a Clojure map, the argument may be an actual instance or subclass of either [`AWSCredentialsProvider`][23] or [`AWSCredentials`][24].
 
-In addition, the credentials map may contain an `:endpoint` entry. If the value of the `:endpoint` key is a lower case, hyphenated translation of one of the [Regions enums][16], [.setRegion][17] will be called on the Client, otherwise [.setEndpoint][18] will be called.
+In addition, the credentials map may contain an `:endpoint` entry. If the value of the `:endpoint` key is a lower case, hyphenated translation of one of the [Regions enums][16], [.withRegion][17] will be used to build the Client, otherwise [.withEndpointConfiguration][18] will be used.
 
 **Note:** The first function called (for each distinct AWS service namespace, e.g. amazonica.aws.ec2) creates an Amazon*Client, which is effectively cached via memoization.  Therefore, if you explicitly pass different credentials maps to different functions, you will effectively have different Clients.
 
@@ -1965,8 +1965,8 @@ Distributed under the Eclipse Public License, the same as Clojure.
 [14]: https://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-roles.html
 [15]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html
 [16]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/regions/Regions.html
-[17]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/AmazonWebServiceClient.html#setRegion-com.amazonaws.regions.Region-
-[18]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/AmazonWebServiceClient.html#setEndpoint-java.lang.String-
+[17]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/client/builder/AwsClientBuilder.html#withRegion-com.amazonaws.regions.Regions-
+[18]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/client/builder/AwsClientBuilder.html#withEndpointConfiguration-com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration-
 [19]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/kinesis/model/Record.html#getData--
 [20]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/BasicAWSCredentials.html
 [21]: https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/BasicSessionCredentials.html


### PR DESCRIPTION
Previously this was `nil` - this meant that the AWS SDK always defaulted to the `us-east-1` signing region.

The common use case for this setting is to override the endpoint to point to a stub AWS service, e.g. Localstack. In older versions, these services were only single-region aware, so setting an incorrect signingregion did not matter. In newer versions that's not the case, and setting the signing region to a different region to the service fails.

I've tested this with localstack 1.2.0 and a local Kinesis stream running in `eu-west-1` which should be accessable at `arn:aws:kinesis:eu-west-1:000000000000:stream/docker-ingestor-output`. 

Before this change I observed the following error:

```
com.amazonaws.services.kinesis.model.ResourceNotFoundException: Stream arn arn:aws:kinesis:us-east-1:000000000000:stream/docker-ingestor-output not found (Service: AmazonKinesis; Status Code: 400; Error Code: ResourceNotFoundException; Request ID: DJTI64WNM2EP672YO31FLAF2A01I5TLHSJWV4GAUOG82FBA13G0G; Proxy: null)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1879)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleServiceErrorResponse(AmazonHttpClient.java:1418)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1387)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1157)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:814)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:781)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:755)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:715)
    at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:697)
    at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:561)
    at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:541)
    at com.amazonaws.services.kinesis.AmazonKinesisClient.doInvoke(AmazonKinesisClient.java:2980)
    at com.amazonaws.services.kinesis.AmazonKinesisClient.invoke(AmazonKinesisClient.java:2947)
    at com.amazonaws.services.kinesis.AmazonKinesisClient.invoke(AmazonKinesisClient.java:2936)
    at com.amazonaws.services.kinesis.AmazonKinesisClient.executePutRecord(AmazonKinesisClient.java:2078)
    at com.amazonaws.services.kinesis.AmazonKinesisClient.putRecord(AmazonKinesisClient.java:2047)
    at com.amazonaws.services.kinesis.AmazonKinesisClient.putRecord(AmazonKinesisClient.java:2090)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
    at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.base/java.lang.reflect.Method.invoke(Method.java:568)
    at amazonica.core$fn_call$fn__20466.invoke(core.clj:878)
    at amazonica.core$intern_function$fn__20511.doInvoke(core.clj:1065)
    at clojure.lang.RestFn.applyTo(RestFn.java:137)
    at clojure.core$apply.invokeStatic(core.clj:673)
    at clojure.core$partial$fn__5914.doInvoke(core.clj:2660)
    at clojure.lang.RestFn.invoke(RestFn.java:397)
    at amazonica.aws.kinesis$eval24015$fn__24016$fn__24017.doInvoke(kinesis.clj:64)
    at clojure.lang.RestFn.invoke(RestFn.java:457)
    at signal.ingestor.naviga.forwarder$publish_article.invokeStatic(forwarder.clj:7)
    at signal.ingestor.naviga.forwarder$publish_article.invoke(forwarder.clj:6)
    at signal.ingestor.naviga.core$process_article_xml.invokeStatic(core.clj:28)
    ... 21 common frames omitted
```

After this change the request succeeds.

As we first attempt to parse the endpoint with [`AwsHostNameUtils/parseRegion`](https://github.com/aws/aws-sdk-java/blob/1.12.323/aws-java-sdk-core/src/main/java/com/amazonaws/util/AwsHostNameUtils.java), this should handle any more complex cases taht exist, where the endpoint isn't just some localshost/localstack URL like `http://localhost:4566`.

Fixes https://github.com/mcohen01/amazonica/issues/346
