### PR TITLE
Amazonica S3 Client must handle nil Auth creds

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -42,11 +42,11 @@
            java.util.Date))
 
 (defn map-contains?
-  "Will check if the given hash-map contains the specified List<Keys>
+  "Check if hash-map contians the specified value(s)"
   [coll primary-key & other-keys]
-  (let [key-finder (apply some-fn
-                          (conj (or other-keys [])
-                                primary-key))]
+  (let [key-finder (apply some-fn (conj (or other-keys
+  					    [])
+					 primary-key))]
     (some? (key-finder coll))))
 
 (defonce ^:private credential (atom {}))

--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -41,7 +41,7 @@
            java.text.SimpleDateFormat
            java.util.Date))
 
-(defn contains?
+(defn map-contains?
   "Will check if the given hash-map contains the specified List<Keys>
   [coll primary-key & other-keys]
   (let [key-finder (apply some-fn
@@ -200,20 +200,20 @@
     (instance? AWSCredentials credentials)
       (AWSStaticCredentialsProvider. credentials)
     (and (associative? credentials)
-         (contains? credentials :session-token))
+         (map-contains? credentials :session-token))
     (AWSStaticCredentialsProvider.
       (BasicSessionCredentials.
         (:access-key credentials)
         (:secret-key credentials)
         (:session-token credentials)))
     (and (associative? credentials)
-         (contains? credentials :access-key))
+         (map-contains? credentials :access-key))
     (AWSStaticCredentialsProvider.
       (BasicAWSCredentials.
         (:access-key credentials)
         (:secret-key credentials)))
     (and (associative? credentials)
-         (contains? credentials :profile))
+         (map-contains? credentials :profile))
     (ProfileCredentialsProvider.
         (:profile credentials))
     (and (associative? credentials)

--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -46,7 +46,7 @@
   [coll primary-key & other-keys]
   (let [key-finder (apply some-fn
                           (conj (or other-keys [])
-                                pk))]
+                                primary-key))]
     (some? (key-finder coll))))
 
 (defonce ^:private credential (atom {}))

--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -41,6 +41,14 @@
            java.text.SimpleDateFormat
            java.util.Date))
 
+(defn contains?
+  "Will check if the given hash-map contains the specified List<Keys>
+  [coll primary-key & other-keys]
+  (let [key-finder (apply some-fn
+                          (conj (or other-keys [])
+                                pk))]
+    (some? (key-finder coll))))
+
 (defonce ^:private credential (atom {}))
 
 (defonce ^:private client-config (atom {}))

--- a/test/amazonica/test/core.clj
+++ b/test/amazonica/test/core.clj
@@ -251,6 +251,6 @@
   validate-contains?-doesnt-allow-nil-values
   (testing "map-contains? shouldn't consider nil values"
     (let [sample-value {:A "some-value" :B nil}]
-      (is true? (c/map-contains? sample-value :A))
-      (is false? (c/map-contains? sample-value :B))
-      (is true? (c/map-contains? sample-value :A :B)))))
+      (is (true? (c/map-contains? sample-value :A)))
+      (is (false? (c/map-contains? sample-value :B)))
+      (is (true? (c/map-contains? sample-value :A :B))))))

--- a/test/amazonica/test/core.clj
+++ b/test/amazonica/test/core.clj
@@ -246,3 +246,11 @@
                   (is (vector? arglist))
                   (doseq [item arglist]
                     (is (symbol? item))))))))))))
+
+(deftest ^:contains-should-not-consider-nil-values
+  validate-contains?-doesnt-allow-nil-values
+  (testing "contains? shouldn't consider nil values"
+    (let [sample-value {:A "some-value" :B nil}]
+      (is true? (c/contains? sample-value :A))
+      (is false? (c/contains? sample-value :B))
+      (is true? (c/contains? sample-value :A :B)))))

--- a/test/amazonica/test/core.clj
+++ b/test/amazonica/test/core.clj
@@ -249,8 +249,8 @@
 
 (deftest ^:contains-should-not-consider-nil-values
   validate-contains?-doesnt-allow-nil-values
-  (testing "contains? shouldn't consider nil values"
+  (testing "map-contains? shouldn't consider nil values"
     (let [sample-value {:A "some-value" :B nil}]
-      (is true? (c/contains? sample-value :A))
-      (is false? (c/contains? sample-value :B))
-      (is true? (c/contains? sample-value :A :B)))))
+      (is true? (c/map-contains? sample-value :A))
+      (is false? (c/map-contains? sample-value :B))
+      (is true? (c/map-contains? sample-value :A :B)))))


### PR DESCRIPTION
 ## Fixes done
   * Amazonica's _get-credentials_ will opt `DefaultCredentialsProvider` if `secret-keys` aren't provided

 ## Changelog
   * Modified **amazonica.core** * Added **contains?**, which _overrides_ `clojure.core/contains?` and performs the logic operation which returns `true` _iff_ The `collection` contains valid-value specified the `key`

 ## Unit testing
   * ![](https://upcdn.io/W142hJk/image/demo/4mXhbrPLKE.png?w=600&h=600&fit=max&q=70)