### PR TITLE
Do not throw if DefaultAwsRegionProviderChain throws

### DIFF
--- a/src/amazonica/core.clj
+++ b/src/amazonica/core.clj
@@ -6,6 +6,7 @@
   (:import clojure.lang.Reflector
            [com.amazonaws
              AmazonServiceException
+             SdkClientException
              ClientConfiguration]
            [com.amazonaws.auth
              AWSCredentials
@@ -153,12 +154,16 @@
    
    Takes AWS_DEFAULT_REGION as the first priority to match old behaviour. Otherwise, see 
    https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html#default-region-provider-chain
-   for region selection order."
+   for region selection order.
+   
+   Returns nil if no region is defined."
   []
   (or
    (System/getenv "AWS_DEFAULT_REGION")
-   (-> (DefaultAwsRegionProviderChain.)
-       (.getRegion))))
+   (try
+     (.getRegion (DefaultAwsRegionProviderChain.))
+     (catch SdkClientException _
+       nil))))
 
 (defn- builder ^AwsClientBuilder [^Class clazz]
   (let [^Method method (.getMethod clazz "builder" (make-array Class 0))]


### PR DESCRIPTION
Sorry about the succession of changes here - I tested locally and was confident there, but found a change of behaviour when running on CI which likely has implications for production deployments which do not have EC2 metadata available (e.g. ECS with EC2 metadata blocked). 
After the previous change to use `AwsRegionProviderChain`, clients now throw if they cannot obtain a region from `AWS_DEFAULT_REGION`, `AWS_REGION`, `-Daws.region` or the EC2 metadata endpoint. 

This restores previous behaviour of falling back to SDK defaults if no region can be found using the tools available.

The [Java docs for AwsRegionProviderChain.getRegion](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/regions/AwsRegionProviderChain.html) are incorrect - they suggest this method returns a null if no region is unavailable, whereas it actually throws, see
https://github.com/aws/aws-sdk-java/blob/4f62cf09e900eb046749757a8d7f704e1f47ecf8/aws-java-sdk-core/src/main/java/com/amazonaws/regions/AwsRegionProviderChain.java#L59

> // Note: This is a bug in the provider chain. The chain should return null when no region is found according to
> // the interface, but an exception is thrown  here instead. This class is used in too many places to change now.
> // TODO: In 2.0, be sure this bug does not carry through.

_Note: I'm actually not sure why this resulted in a change of behaviour, given `AwsClientBuilder` [falls back to](https://github.com/aws/aws-sdk-java/blob/4f62cf09e900eb046749757a8d7f704e1f47ecf8/aws-java-sdk-core/src/main/java/com/amazonaws/client/builder/AwsClientBuilder.java#L60) `DefaultAwsRegionProviderChain` anyway_