### PR TITLE
Kinesis: Accept cloudwatch and dynamodb credentials providers

### DIFF
--- a/src/amazonica/aws/kinesis.clj
+++ b/src/amazonica/aws/kinesis.clj
@@ -203,7 +203,10 @@
                                           initial-lease-table-write-capacity]
                                    :or {worker-id (str (UUID/randomUUID))}}]
   (cond-> (KinesisClientLibConfiguration. (name app)
-                                          (name stream)
+                                          (cond
+                                            (keyword? stream) (name stream)
+                                            (instance? com.amazonaws.arn.Arn stream) (.getResourceAsString stream)
+                                            :else stream)
                                           provider
                                           (or dynamodb-credentials-provider provider)
                                           (or cloudwatch-credentials-provider provider)
@@ -286,7 +289,10 @@
     (.withInitialLeaseTableReadCapacity initial-lease-table-read-capacity)
 
     initial-lease-table-write-capacity
-    (.withInitialLeaseTableWriteCapacity initial-lease-table-write-capacity)))
+    (.withInitialLeaseTableWriteCapacity initial-lease-table-write-capacity)
+
+    (instance? com.amazonaws.arn.Arn stream)
+    (.withStreamArn stream)))
 
 (defn worker
   "Instantiate a kinesis Worker."

--- a/src/amazonica/aws/kinesis.clj
+++ b/src/amazonica/aws/kinesis.clj
@@ -205,7 +205,9 @@
   (cond-> (KinesisClientLibConfiguration. (name app)
                                           (cond
                                             (keyword? stream) (name stream)
-                                            (instance? com.amazonaws.arn.Arn stream) (.getResourceAsString stream)
+                                            (instance? com.amazonaws.arn.Arn stream) (-> stream
+                                                                                         (.getResource)
+                                                                                         (.getResource))
                                             :else stream)
                                           provider
                                           (or dynamodb-credentials-provider provider)


### PR DESCRIPTION
Relatively minor change to use the 6 artity constructor of KinesisClientLibConfiguration (https://github.com/awslabs/amazon-kinesis-client/blob/v1.15.2/src/main/java/com/amazonaws/services/kinesis/clientlibrary/lib/worker/KinesisClientLibConfiguration.java#L357-L362) to allow using separate credentials providers for DynamoDB and CloudWatch.

This is necessary to use a DynamoDB lease table in a separate account to a Kinesis stream being read.

This additionally accepts `stream` arguments of type `Arn` to allow full ARNs to be used for cross-account reads.